### PR TITLE
Add SNI and ALPN suppor for tls layer #61

### DIFF
--- a/microproxy/context.py
+++ b/microproxy/context.py
@@ -2,12 +2,14 @@ class Context(object):
     def __init__(self,
                  src_stream=None,
                  dest_stream=None,
+                 schema=None,
                  host=None,
                  port=None,
                  config=None,
                  layer_manager=None):
         self.src_stream = src_stream
         self.dest_stream = dest_stream
+        self.schema = schema
         self.host = host
         self.port = port
         self.config = config

--- a/microproxy/context.py
+++ b/microproxy/context.py
@@ -5,12 +5,10 @@ class Context(object):
                  schema=None,
                  host=None,
                  port=None,
-                 config=None,
-                 layer_manager=None):
+                 config=None):
         self.src_stream = src_stream
         self.dest_stream = dest_stream
         self.schema = schema
         self.host = host
         self.port = port
         self.config = config
-        self.layer_manager = layer_manager

--- a/microproxy/context.py
+++ b/microproxy/context.py
@@ -2,13 +2,13 @@ class Context(object):
     def __init__(self,
                  src_stream=None,
                  dest_stream=None,
-                 schema=None,
+                 scheme=None,
                  host=None,
                  port=None,
                  config=None):
         self.src_stream = src_stream
         self.dest_stream = dest_stream
-        self.schema = schema
+        self.scheme = scheme
         self.host = host
         self.port = port
         self.config = config

--- a/microproxy/iostream.py
+++ b/microproxy/iostream.py
@@ -18,6 +18,7 @@ class MicroProxyIOStream(IOStream):
 
     def pause(self):
         self.socket.setblocking(True)
+        self._state = None
         self.io_loop.remove_handler(self.socket)
 
     def resume(self):

--- a/microproxy/iostream.py
+++ b/microproxy/iostream.py
@@ -1,0 +1,149 @@
+from tornado.iostream import IOStream, SSLIOStream, StreamClosedError
+from tornado.concurrent import TracebackFuture
+import socket
+from OpenSSL import SSL
+
+import errno
+_ERRNO_WOULDBLOCK = (errno.EWOULDBLOCK, errno.EAGAIN)
+
+class MicroProxyIOStream(IOStream):
+    def __init__(self, sock, **kwargs):
+        super(MicroProxyIOStream, self).__init__(sock, **kwargs)
+
+    def start_tls(self, server_side, ssl_options, server_hostname=None):
+        if (self._read_callback or self._read_future or
+                self._write_callback or self._write_future or
+                self._connect_callback or self._connect_future or
+                self._pending_callbacks or self._closed or
+                self._read_buffer or self._write_buffer):
+            raise ValueError("IOStream is not idle; cannot convert to SSL")
+
+        if not isinstance(ssl_options, SSL.Context):
+            raise ValueError("ssl_options is not SSL.Context")
+
+        socket = self.socket
+        self.io_loop.remove_handler(socket)
+        self.socket = None
+        socket = SSL.Connection(ssl_options, socket)
+        if server_side:
+            socket.set_accept_state()
+        else:
+            socket.set_connect_state()
+
+        orig_close_callback = self._close_callback
+        self._close_callback = None
+
+        future = TracebackFuture()
+        ssl_stream = MicroProxySSLIOStream(socket,
+                                           ssl_options=ssl_options,
+                                           io_loop=self.io_loop)
+
+        def close_callback():
+            if not future.done():
+                future.set_exception(ssl_stream.error or StreamClosedError())
+            if orig_close_callback is not None:
+                orig_close_callback()
+
+        ssl_stream.set_close_callback(close_callback)
+        ssl_stream._ssl_connect_callback = lambda: future.set_result(ssl_stream)
+        ssl_stream.max_buffer_size = self.max_buffer_size
+        ssl_stream.read_chunk_size = self.read_chunk_size
+        return future
+
+
+class MicroProxySSLIOStream(SSLIOStream):
+    def __init__(self, sock, **kwargs):
+        super(MicroProxySSLIOStream, self).__init__(sock, **kwargs)
+
+    def _do_ssl_handshake(self):
+        # Based on code from test_ssl.py in the python stdlib
+        try:
+            self._handshake_reading = False
+            self._handshake_writing = False
+            self.socket.do_handshake()
+
+        except SSL.WantReadError:
+            self._handshake_reading = True
+            return
+        except SSL.WantWriteError:
+            self._handshake_writing = True
+            return
+
+        except socket.error as err:
+            # Some port scans (e.g. nmap in -sT mode) have been known
+            # to cause do_handshake to raise EBADF and ENOTCONN, so make
+            # those errors quiet as well.
+            # https://groups.google.com/forum/?fromgroups#!topic/python-tornado/ApucKJat1_0
+            if (self._is_connreset(err) or
+                    err.args[0] in (errno.EBADF, errno.ENOTCONN)):
+                return self.close(exc_info=True)
+            raise
+        except AttributeError:
+            # On Linux, if the connection was reset before the call to
+            # wrap_socket, do_handshake will fail with an
+            # AttributeError.
+            return self.close(exc_info=True)
+        else:
+            self._ssl_accepting = False
+            # if not self._verify_cert(self.socket.get_peer_cert()):
+            #     self.close()
+            #     return
+            self._run_ssl_connect_callback()
+
+    def _verify_cert(self, peercert):
+        pass
+        # if isinstance(self._ssl_options, dict):
+        #     verify_mode = self._ssl_options.get('cert_reqs', ssl.CERT_NONE)
+        # elif isinstance(self._ssl_options, ssl.SSLContext):
+        #     verify_mode = self._ssl_options.verify_mode
+        # assert verify_mode in (ssl.CERT_NONE, ssl.CERT_REQUIRED, ssl.CERT_OPTIONAL)
+        # if verify_mode == ssl.CERT_NONE or self._server_hostname is None:
+        #     return True
+        # cert = self.socket.getpeercert()
+        # if cert is None and verify_mode == ssl.CERT_REQUIRED:
+        #     gen_log.warning("No SSL certificate given")
+        #     return False
+        # try:
+        #     ssl_match_hostname(peercert, self._server_hostname)
+        # except SSLCertificateError as e:
+        #     gen_log.warning("Invalid SSL certificate: %s" % e)
+        #     return False
+        # else:
+        #     return True
+
+    def write_to_fd(self, data):
+        try:
+            return self.socket.send(data)
+        except SSL.WantWriteError:
+            return 0
+        except SSL.Error:
+            raise
+
+    def read_from_fd(self):
+        if self._ssl_accepting:
+            # If the handshake hasn't finished yet, there can't be anything
+            # to read (attempting to read may or may not raise an exception
+            # depending on the SSL version)
+            return None
+        try:
+            # SSLSocket objects have both a read() and recv() method,
+            # while regular sockets only have recv().
+            # The recv() method blocks (at least in python 2.6) if it is
+            # called when there is nothing to read, so we have to use
+            # read() instead.
+            chunk = self.socket.read(self.read_chunk_size)
+        except SSL.WantReadError:
+            return None
+
+        except SSL.Error:
+                raise
+
+        except socket.error as e:
+            if e.args[0] in _ERRNO_WOULDBLOCK:
+                return None
+            else:
+                raise
+        if not chunk:
+            self.close()
+            return None
+        return chunk

--- a/microproxy/layer/__init__.py
+++ b/microproxy/layer/__init__.py
@@ -1,2 +1,2 @@
-from application import Http1Layer, TlsLayer, ForwardLayer
+from application import Http1Layer, TlsLayer, ForwardLayer, NonTlsLayer
 from proxy import SocksLayer, TransparentLayer

--- a/microproxy/layer/application/__init__.py
+++ b/microproxy/layer/application/__init__.py
@@ -1,3 +1,4 @@
 from http1 import Http1Layer
 from tls import TlsLayer
 from forward import ForwardLayer
+from nontls import NonTlsLayer

--- a/microproxy/layer/application/forward.py
+++ b/microproxy/layer/application/forward.py
@@ -18,6 +18,7 @@ class ForwardLayer(object):
         self.context.dest_stream.read_until_close(streaming_callback=self.on_response)
         self.context.dest_stream.set_close_callback(self.on_dest_close)
         yield self._future
+        raise gen.Return(self.context)
 
     def on_src_close(self):
         self.context.dest_stream.close()

--- a/microproxy/layer/application/forward.py
+++ b/microproxy/layer/application/forward.py
@@ -12,7 +12,7 @@ class ForwardLayer(object):
         self._future = concurrent.Future()
 
     @gen.coroutine
-    def process(self):
+    def process_and_return_context(self):
         self.context.src_stream.read_until_close(streaming_callback=self.on_request)
         self.context.src_stream.set_close_callback(self.on_src_close)
         self.context.dest_stream.read_until_close(streaming_callback=self.on_response)

--- a/microproxy/layer/application/http1.py
+++ b/microproxy/layer/application/http1.py
@@ -22,7 +22,7 @@ class Http1Layer(httputil.HTTPServerConnectionDelegate):
         signal("http1layer_error").connect(self.on_error, sender=self)
 
     @gen.coroutine
-    def process(self):
+    def process_and_return_context(self):
         http_server_connection = http1connection.HTTP1ServerConnection(self.context.src_stream)
         http_server_connection.start_serving(self)
         yield self._future

--- a/microproxy/layer/application/http1.py
+++ b/microproxy/layer/application/http1.py
@@ -1,3 +1,4 @@
+from copy import copy
 from tornado import iostream
 from tornado import gen
 from tornado import httputil
@@ -15,7 +16,7 @@ logger = get_logger(__name__)
 class Http1Layer(httputil.HTTPServerConnectionDelegate):
     def __init__(self, context):
         super(Http1Layer, self).__init__()
-        self.context = context
+        self.context = copy(context)
         self.http_forwarder = None
         self._future = concurrent.Future()
         signal("http1layer_error").connect(self.on_error, sender=self)
@@ -25,6 +26,7 @@ class Http1Layer(httputil.HTTPServerConnectionDelegate):
         http_server_connection = http1connection.HTTP1ServerConnection(self.context.src_stream)
         http_server_connection.start_serving(self)
         yield self._future
+        raise gen.Return(self.context)
 
     def start_request(self, server_conn, request_conn):
         dest_conn = http1connection.HTTP1Connection(self.context.dest_stream,

--- a/microproxy/layer/application/nontls.py
+++ b/microproxy/layer/application/nontls.py
@@ -1,0 +1,18 @@
+from copy import copy
+from tornado import gen
+from tornado import iostream
+
+
+class NonTlsLayer(object):
+    def __init__(self, context):
+        super(NonTlsLayer, self).__init__()
+        self.context = copy(context)
+
+    @gen.coroutine
+    def process(self):
+        # we are not going through tls layer
+        # chage dest_stream to iostream
+        self.context.dest_stream.setblocking(False)
+        self.context.dest_stream = iostream.IOStream(self.context.dest_stream)
+        self.context.schema = "http"
+        raise gen.Return(self.context)

--- a/microproxy/layer/application/nontls.py
+++ b/microproxy/layer/application/nontls.py
@@ -15,5 +15,5 @@ class NonTlsLayer(object):
         self.context.src_stream.resume()
         self.context.dest_stream.setblocking(False)
         self.context.dest_stream = iostream.IOStream(self.context.dest_stream)
-        self.context.schema = "http"
+        self.context.scheme = "http"
         raise gen.Return(self.context)

--- a/microproxy/layer/application/nontls.py
+++ b/microproxy/layer/application/nontls.py
@@ -12,6 +12,7 @@ class NonTlsLayer(object):
     def process(self):
         # we are not going through tls layer
         # chage dest_stream to iostream
+        self.context.src_stream.resume()
         self.context.dest_stream.setblocking(False)
         self.context.dest_stream = iostream.IOStream(self.context.dest_stream)
         self.context.schema = "http"

--- a/microproxy/layer/application/nontls.py
+++ b/microproxy/layer/application/nontls.py
@@ -9,7 +9,7 @@ class NonTlsLayer(object):
         self.context = copy(context)
 
     @gen.coroutine
-    def process(self):
+    def process_and_return_context(self):
         # we are not going through tls layer
         # chage dest_stream to iostream
         self.context.src_stream.resume()

--- a/microproxy/layer/application/tls.py
+++ b/microproxy/layer/application/tls.py
@@ -73,6 +73,7 @@ class TlsLayer(object):
 
     @gen.coroutine
     def process(self):
+        self.context.src_stream.resume()
         src_ssl_ctx = self.create_src_sslcontext()
         try:
             src_stream = yield self.context.src_stream.start_tls(server_side=True,

--- a/microproxy/layer/application/tls.py
+++ b/microproxy/layer/application/tls.py
@@ -1,8 +1,8 @@
-import ssl
+from OpenSSL import SSL
 from copy import copy
 from tornado import gen
-from tornado.iostream import SSLIOStream
 
+from microproxy.iostream import MicroProxySSLIOStream
 from microproxy.utils import get_logger
 logger = get_logger(__name__)
 
@@ -14,60 +14,63 @@ class TlsLayer(object):
         super(TlsLayer, self).__init__()
         self.context = copy(context)
         self.ssl_sock = None
-        self.alpn_info = ""
 
-    def sni_callback(self, ssl_socket, server_hostname, ssl_context):
+    def src_alpn_callback(self, src_ssl_conn, alpn):
         try:
-            dest_context = self.create_dest_sslcontext()
-            self.ssl_sock = dest_context.wrap_socket(self.context.dest_stream,
-                                                     server_hostname=server_hostname)
+            dest_context = self.create_dest_sslcontext(alpn)
+            self.ssl_sock = SSL.Connection(dest_context,
+                                           self.context.dest_stream)
+            self.ssl_sock.set_tlsext_host_name(self.context.host)
+            self.ssl_sock.set_connect_state()
+            self.ssl_sock.do_handshake()
 
-            if ssl.HAS_ALPN:
-                self.alpn_info = self.ssl_sock.selected_alpn_protocol()
-                if self.alpn_info == 'h2':
-                    logger.debug("alpn using h2")
-                    ssl_context.set_alpn_protocols(['h2'])
-                else:
-                    logger.debug("alpn using http/1.1")
-                    ssl_context.set_alpn_protocols(['http/1.1'])
+            alpn_info = self.ssl_sock.get_alpn_proto_negotiated()
+
+            if alpn_info == "http/1.1":
+                self.context.schema = "https"
+            elif alpn_info == "h2":
+                self.context.schema = "h2"
+            else:
+                self.context.schema = "https"
+            return bytes(alpn_info)
 
         except Exception as e:
             logger.exception(e)
-            return ssl.ALERT_DESCRIPTION_HANDSHAKE_FAILURE
+            raise
         return None
 
-    def create_dest_sslcontext(self):
-        dest_ssl_context = ssl.create_default_context()
-        if ssl.HAS_ALPN:
-            dest_ssl_context.set_alpn_protocols(self.SUPPORT_PROTOCOLS)
-        if ssl.HAS_NPN:
-            dest_ssl_context.set_npn_protocols(self.SUPPORT_PROTOCOLS)
+    def src_sni_callback(self, src_ssl_conn):
+        self.context.host = src_ssl_conn.get_servername()
+
+    def create_dest_sslcontext(self, alpn):
+        dest_ssl_context = SSL.Context(SSL.SSLv23_METHOD)
+        dest_ssl_context.set_alpn_protos(alpn)
 
         return dest_ssl_context
 
     def create_src_sslcontext(self):
-        context = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
-        context.load_cert_chain(self.context.config["certfile"],
-                                self.context.config["keyfile"])
-        context.set_servername_callback(self.sni_callback)
+        context = SSL.Context(SSL.SSLv23_METHOD)
+        context.use_certificate_file(self.context.config["certfile"])
+        context.use_privatekey_file(self.context.config["keyfile"])
+        context.set_tlsext_servername_callback(self.src_sni_callback)
+        context.set_alpn_select_callback(self.src_alpn_callback)
 
         return context
 
     @gen.coroutine
     def process(self):
         src_ssl_context = self.create_src_sslcontext()
-        src_stream = yield self.context.src_stream.start_tls(server_side=True,
-                                                             ssl_options=src_ssl_context)
+        try:
+            src_stream = yield self.context.src_stream.start_tls(server_side=True,
+                                                                 ssl_options=src_ssl_context)
+        except Exception as e:
+            logger.exception(e)
+            raise
+
         self.ssl_sock.setblocking(False)
-        dest_stream = SSLIOStream(self.ssl_sock)
+        dest_stream = MicroProxySSLIOStream(self.ssl_sock)
 
         self.context.src_stream = src_stream
         self.context.dest_stream = dest_stream
 
-        if self.alpn_info == "http/1.1":
-            self.context.schema = "https"
-        elif self.alpn_info == "h2":
-            self.context.schema = "h2"
-        else:
-            self.context.schema = "https"
         raise gen.Return(self.context)

--- a/microproxy/layer/application/tls.py
+++ b/microproxy/layer/application/tls.py
@@ -2,30 +2,77 @@ import ssl
 from copy import copy
 from tornado import gen
 from tornado import concurrent
+from tornado.iostream import SSLIOStream
 
 from microproxy.utils import get_logger
 logger = get_logger(__name__)
 
 
 class TlsLayer(object):
+    SUPPORT_PROTOCOLS = ["http/1.1"]
+
     def __init__(self, context):
         super(TlsLayer, self).__init__()
         self.context = context
+        self.ssl_sock = None
+        self.alpn_info = ""
+
+    def sni_callback(self, ssl_socket, server_hostname, ssl_context):
+        try:
+            dest_context = self.create_dest_sslcontext()
+            self.ssl_sock = dest_context.wrap_socket(self.context.dest_stream,
+                                                     server_hostname=server_hostname)
+
+            if ssl.HAS_ALPN:
+                self.alpn_info = self.ssl_sock.selected_alpn_protocol()
+                if self.alpn_info == 'h2':
+                    logger.debug("alpn using h2")
+                    ssl_context.set_alpn_protocols(['h2'])
+                else:
+                    logger.debug("alpn using http/1.1")
+                    ssl_context.set_alpn_protocols(['http/1.1'])
+
+        except Exception as e:
+            logger.exception(e)
+            return ssl.ALERT_DESCRIPTION_HANDSHAKE_FAILURE
+        return None
+
+    def create_dest_sslcontext(self):
+        dest_ssl_context = ssl.create_default_context()
+        if ssl.HAS_ALPN:
+            dest_ssl_context.set_alpn_protocols(self.SUPPORT_PROTOCOLS)
+        if ssl.HAS_NPN:
+            dest_ssl_context.set_npn_protocols(self.SUPPORT_PROTOCOLS)
+
+        return dest_ssl_context
+
+    def create_src_sslcontext(self):
+        context = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+        context.load_cert_chain(self.context.config["certfile"],
+                                self.context.config["keyfile"])
+        context.set_servername_callback(self.sni_callback)
+
+        return context
 
     @gen.coroutine
     def process(self):
-        server_ssl_options = dict(certfile=self.context.config["certfile"],
-                                  keyfile=self.context.config["keyfile"],)
+        src_ssl_context = self.create_src_sslcontext()
         src_stream = yield self.context.src_stream.start_tls(server_side=True,
-                                                             ssl_options=server_ssl_options)
-
-        dest_stream = yield self.context.dest_stream.start_tls(server_side=False,
-                                                               ssl_options=dict(cert_reqs=ssl.CERT_NONE),
-                                                               server_hostname=self.context.host)
+                                                             ssl_options=src_ssl_context)
+        self.ssl_sock.setblocking(False)
+        dest_stream = SSLIOStream(self.ssl_sock)
 
         new_context = copy(self.context)
         new_context.src_stream = src_stream
         new_context.dest_stream = dest_stream
+
+        if self.alpn_info == "http/1.1":
+            new_context.schema = "https"
+        elif self.alpn_info == "h2":
+            new_context.schema = "h2"
+        else:
+            new_context.schema = "https"
+
         process_result = self.context.layer_manager.next_layer(self, new_context).process()
         if isinstance(process_result, concurrent.Future):
             yield process_result

--- a/microproxy/layer/application/tls.py
+++ b/microproxy/layer/application/tls.py
@@ -35,11 +35,11 @@ class TlsLayer(object):
                 alpn_info = b"http/1.1"
 
             if alpn_info == "http/1.1":
-                self.context.schema = "https"
+                self.context.scheme = "https"
             elif alpn_info == "h2":
-                self.context.schema = "h2"
+                self.context.scheme = "h2"
             else:
-                self.context.schema = "https"
+                self.context.scheme = "https"
 
             logger.debug("Choose {0} as application protocol".format(alpn_info))
             return bytes(alpn_info)

--- a/microproxy/layer/proxy/base.py
+++ b/microproxy/layer/proxy/base.py
@@ -10,7 +10,7 @@ class ProxyLayer(object):
         super(ProxyLayer, self).__init__()
         self.context = copy(context)
 
-    def process(self):
+    def process_and_return_context(self):
         raise NotImplementedError
 
     def create_dest_stream(self, dest_addr_info):

--- a/microproxy/layer/proxy/base.py
+++ b/microproxy/layer/proxy/base.py
@@ -1,8 +1,4 @@
 import socket
-import datetime
-
-from tornado import gen
-from tornado import iostream
 
 from microproxy.utils import get_logger
 logger = get_logger(__name__)
@@ -16,13 +12,11 @@ class ProxyLayer(object):
     def process(self):
         raise NotImplementedError
 
-    @gen.coroutine
     def create_dest_stream(self, dest_addr_info):
         dest_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0)
-        dest_stream = iostream.IOStream(dest_socket)
+        dest_socket.setblocking(True)
         try:
-            yield gen.with_timeout(datetime.timedelta(5), dest_stream.connect(dest_addr_info))
-            raise gen.Return(dest_stream)
-        except gen.TimeoutError:
-            logger.warning("Connect to Destination Timeout")
+            dest_socket.connect(dest_addr_info)
+            return dest_socket
+        except:
             raise

--- a/microproxy/layer/proxy/base.py
+++ b/microproxy/layer/proxy/base.py
@@ -1,4 +1,5 @@
 import socket
+from copy import copy
 
 from microproxy.utils import get_logger
 logger = get_logger(__name__)
@@ -7,7 +8,7 @@ logger = get_logger(__name__)
 class ProxyLayer(object):
     def __init__(self, context):
         super(ProxyLayer, self).__init__()
-        self.context = context
+        self.context = copy(context)
 
     def process(self):
         raise NotImplementedError

--- a/microproxy/layer/proxy/socks.py
+++ b/microproxy/layer/proxy/socks.py
@@ -43,16 +43,19 @@ class SocksLayer(ProxyLayer):
         super(SocksLayer, self).__init__(context)
 
     @gen.coroutine
-    def process(self):
-        yield self.socks_greeting()
-        host, port, addr_type = yield self.socks_request()
-        dest_stream = yield self.socks_response_with_dest_stream_creation(host, port, addr_type)
+    def process_and_return_context(self):
+        try:
+            yield self.socks_greeting()
+            host, port, addr_type = yield self.socks_request()
+            dest_stream = yield self.socks_response_with_dest_stream_creation(host, port, addr_type)
 
-        self.context.src_stream.pause()
-        self.context.dest_stream = dest_stream
-        self.context.host = host
-        self.context.port = port
-        raise gen.Return(self.context)
+            self.context.src_stream.pause()
+            self.context.dest_stream = dest_stream
+            self.context.host = host
+            self.context.port = port
+            raise gen.Return(self.context)
+        except:
+            raise
 
     @gen.coroutine
     def socks_greeting(self):

--- a/microproxy/layer/proxy/socks.py
+++ b/microproxy/layer/proxy/socks.py
@@ -124,7 +124,7 @@ class SocksLayer(ProxyLayer):
     @gen.coroutine
     def socks_response_with_dest_stream_creation(self, host, port, addr_type):
         src_stream = self.context.src_stream
-        dest_stream = yield self.create_dest_stream((host, port))
+        dest_stream = self.create_dest_stream((host, port))
         try:
             yield src_stream.write(struct.pack("!BBx",
                                                self.SOCKS_VERSION,

--- a/microproxy/layer/proxy/socks.py
+++ b/microproxy/layer/proxy/socks.py
@@ -48,6 +48,7 @@ class SocksLayer(ProxyLayer):
         host, port, addr_type = yield self.socks_request()
         dest_stream = yield self.socks_response_with_dest_stream_creation(host, port, addr_type)
 
+        self.context.src_stream.pause()
         self.context.dest_stream = dest_stream
         self.context.host = host
         self.context.port = port

--- a/microproxy/layer/proxy/transparent.py
+++ b/microproxy/layer/proxy/transparent.py
@@ -31,6 +31,7 @@ class TransparentLayer(ProxyLayer):
     def process(self):
         host, port = self._get_dest_addr()
         dest_stream = yield self.create_dest_stream((host, port))
+        self.context.src_stream.pause()
         self.context.dest_stream = dest_stream
         self.context.host = host
         self.context.port = port

--- a/microproxy/layer/proxy/transparent.py
+++ b/microproxy/layer/proxy/transparent.py
@@ -1,10 +1,8 @@
 import platform
 import socket
 import struct
-from copy import copy
 
 from tornado import gen
-from tornado import concurrent
 
 from base import ProxyLayer
 
@@ -33,18 +31,8 @@ class TransparentLayer(ProxyLayer):
     def process(self):
         host, port = self._get_dest_addr()
         dest_stream = yield self.create_dest_stream((host, port))
-        new_context = copy(self.context)
-        new_context.dest_stream = dest_stream
-        new_context.host = host
-        new_context.port = port
+        self.context.dest_stream = dest_stream
+        self.context.host = host
+        self.context.port = port
 
-        try:
-            process_result = self.context.layer_manager.next_layer(self, new_context).process()
-            if isinstance(process_result, concurrent.Future):
-                yield process_result
-            raise gen.Return(None)
-        finally:
-            try:
-                dest_stream.close()
-            except:
-                pass
+        raise gen.Return(self.context)

--- a/microproxy/layer/proxy/transparent.py
+++ b/microproxy/layer/proxy/transparent.py
@@ -28,7 +28,7 @@ class TransparentLayer(ProxyLayer):
         return (address, port)
 
     @gen.coroutine
-    def process(self):
+    def process_and_return_context(self):
         host, port = self._get_dest_addr()
         dest_stream = yield self.create_dest_stream((host, port))
         self.context.src_stream.pause()

--- a/microproxy/proxy.py
+++ b/microproxy/proxy.py
@@ -1,11 +1,9 @@
-from copy import copy
 from tornado import tcpserver
 from tornado import gen
-from tornado import concurrent
 from tornado import iostream
 
 from context import Context
-from layer import SocksLayer, TransparentLayer, Http1Layer, ForwardLayer, TlsLayer
+from layer import SocksLayer, TransparentLayer, Http1Layer, ForwardLayer, TlsLayer, NonTlsLayer
 
 from utils import curr_loop, get_logger
 from interceptor import MsgPublisherInterceptor as Interceptor
@@ -15,17 +13,50 @@ logger = get_logger(__name__)
 
 
 class LayerManager(object):
-    def start_layer(self, context):
-        mode = context.config["mode"]
-        if mode == "socks":
-            return SocksLayer(context)
-        elif mode == "transparent":
-            return TransparentLayer(context)
-        else:
-            # fixme: due to fail fast, need raise exception here
-            logger.warning("Unsupport proxy mode : {0}".format(mode))
+    def __init__(self, src_stream, config):
+        self.src_stream = src_stream
+        self.config = config
 
-    def next_layer(self, current_layer, context, alpn_info=None):
+    @gen.coroutine
+    def start_layer(self):
+        mode = self.config["mode"]
+        if mode == "socks":
+            layer_constructor = SocksLayer
+        elif mode == "transparent":
+            layer_constructor = TransparentLayer
+        else:
+            logger.error("Unsupport proxy mode : {0}".format(mode))
+            raise ValueError
+
+        current_context = Context(src_stream=self.src_stream,
+                                  config=self.config)
+        while True:
+            try:
+                current_layer = layer_constructor(current_context)
+                logger.debug("Enter {0} Layer".format(current_layer))
+                current_context = yield current_layer.process()
+                logger.debug("Leave {0} Layer".format(current_layer))
+                layer_constructor = self.next_layer(current_layer, current_context)
+
+                if not layer_constructor:
+                    logger.debug("Layer Loop Ended")
+                    break
+            except gen.TimeoutError:
+                self.src_stream.close()
+            except DestStreamClosedError:
+                logger.error("destination stream closed unexceptedly")
+                self.src_stream.close()
+            except SrcStreamClosedError:
+                logger.error("source stream closed unexceptedly")
+            except iostream.StreamClosedError:
+                logger.error("stream closed")
+                self.src_stream.close()
+            except Exception:
+                raise
+
+        raise gen.Return(None)
+
+    def next_layer(self, current_layer, context):
         try:
             http_ports = [80]
             http_ports.extend(context.config["http_port"])
@@ -36,24 +67,17 @@ class LayerManager(object):
 
         if isinstance(current_layer, SocksLayer) or isinstance(current_layer, TransparentLayer):
             if context.port in http_ports:
-                # we are not going through tls layer
-                # chage dest_stream to iostream
-                new_context = copy(context)
-                new_context.dest_stream.setblocking(False)
-                new_context.dest_stream = iostream.IOStream(new_context.dest_stream)
-                new_context.schema = "http"
-                return Http1Layer(new_context)
+                return NonTlsLayer
             elif context.port in https_ports:
-                return TlsLayer(context)
+                return TlsLayer
             else:
-                return ForwardLayer(context)
+                return ForwardLayer
 
-        if isinstance(current_layer, TlsLayer):
-            if context.port in https_ports:
-                if context.schema == "https":
-                    return Http1Layer(context)
-                elif context.schema == "h2":
-                    return ForwardLayer(context)
+        if isinstance(current_layer, TlsLayer) or isinstance(current_layer, NonTlsLayer):
+            if context.schema == "http" or context.schema == "https":
+                return Http1Layer
+            elif context.schema == "h2":
+                return ForwardLayer
 
 
 class ProxyServer(tcpserver.TCPServer):
@@ -63,28 +87,13 @@ class ProxyServer(tcpserver.TCPServer):
         self.host = config["host"]
         self.port = config["port"]
         self.interceptor = Interceptor(config=config)
-        self.layer_manager = LayerManager()
 
     @gen.coroutine
     def handle_stream(self, stream, port):
         try:
-            context = Context(src_stream=stream,
-                              config=self.config,
-                              layer_manager=self.layer_manager)
-
-            process_result = self.layer_manager.start_layer(context).process()
-            if isinstance(process_result, concurrent.Future):
-                yield process_result
-        except gen.TimeoutError:
-            stream.close()
-        except DestStreamClosedError:
-            logger.error("destination stream closed unexceptedly")
-            stream.close()
-        except SrcStreamClosedError:
-            logger.error("source stream closed unexceptedly")
-        except iostream.StreamClosedError:
-            logger.error("stream closed")
-            stream.close()
+            logger.debug("Start new layer manager")
+            layer_manager = LayerManager(stream, self.config)
+            yield layer_manager.start_layer()
         except Exception as e:
             # not handle exception, log it and close the stream
             logger.exception(e)

--- a/microproxy/proxy.py
+++ b/microproxy/proxy.py
@@ -35,7 +35,7 @@ class LayerManager(object):
             try:
                 current_layer = layer_constructor(current_context)
                 logger.debug("Enter {0} Layer".format(current_layer))
-                current_context = yield current_layer.process()
+                current_context = yield current_layer.process_and_return_context()
                 logger.debug("Leave {0} Layer".format(current_layer))
                 layer_constructor = self.next_layer(current_layer, current_context)
 
@@ -104,6 +104,8 @@ class ProxyServer(tcpserver.TCPServer):
                 self.io_loop.add_future(future, lambda f: f.result())
         except Exception as e:
             logger.exception(e)
+            raise
+
 
     @gen.coroutine
     def handle_stream(self, stream, port):
@@ -115,6 +117,7 @@ class ProxyServer(tcpserver.TCPServer):
             # not handle exception, log it and close the stream
             logger.exception(e)
             stream.close()
+            raise
 
     def start_listener(self):
         self.listen(self.port, self.host)

--- a/microproxy/proxy.py
+++ b/microproxy/proxy.py
@@ -44,14 +44,18 @@ class LayerManager(object):
                     break
             except gen.TimeoutError:
                 self.src_stream.close()
+                break
             except DestStreamClosedError:
                 logger.error("destination stream closed unexceptedly")
                 self.src_stream.close()
+                break
             except SrcStreamClosedError:
                 logger.error("source stream closed unexceptedly")
+                break
             except iostream.StreamClosedError:
                 logger.error("stream closed")
                 self.src_stream.close()
+                break
             except Exception:
                 raise
 
@@ -75,9 +79,9 @@ class LayerManager(object):
                 return ForwardLayer
 
         if isinstance(current_layer, TlsLayer) or isinstance(current_layer, NonTlsLayer):
-            if context.schema == "http" or context.schema == "https":
+            if context.scheme == "http" or context.scheme == "https":
                 return Http1Layer
-            elif context.schema == "h2":
+            elif context.scheme == "h2":
                 return ForwardLayer
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 tornado==4.3
 pyzmq==15.2.0
 blinker==1.4
+ipaddress==1.0.16
+pyOpenSSL==16.0.0
 mock==2.0.0
 coverage==4.0.3
 coveralls==1.1
-ipaddress==1.0.16

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ pyzmq==15.2.0
 blinker==1.4
 ipaddress==1.0.16
 pyOpenSSL==16.0.0
+service-identity==16.0.0
 mock==2.0.0
 coverage==4.0.3
 coveralls==1.1

--- a/tests/layer/test_forward.py
+++ b/tests/layer/test_forward.py
@@ -43,7 +43,7 @@ class ForwardLayerTest(AsyncTestCase):
 
     @gen_test
     def test_forward_message(self):
-        self.forward_layer.process()
+        self.forward_layer.process_and_return_context()
         self.src_stream.write(b"aaa\r\n")
         message = yield self.dest_stream.read_until(b"\r\n")
         assert message == b"aaa\r\n"

--- a/tests/layer/test_http1.py
+++ b/tests/layer/test_http1.py
@@ -43,8 +43,8 @@ class Http1LayerTest(AsyncTestCase):
         self.http_layer = Http1Layer(self.context)
 
     @gen_test
-    def test_process_normal(self):
-        http_layer_future = self.http_layer.process()
+    def test_process_and_return_context_normal(self):
+        http_layer_future = self.http_layer.process_and_return_context()
         self.src_stream.write(b"\r\n".join([b"GET /index HTTP/1.1",
                                             b"\r\n"]))
         req_header = yield self.dest_stream.read_until("\r\n\r\n")
@@ -72,7 +72,7 @@ class Http1LayerTest(AsyncTestCase):
 
     @gen_test
     def test_write_req_to_dest_failed(self):
-        http_layer_future = self.http_layer.process()
+        http_layer_future = self.http_layer.process_and_return_context()
         self.dest_stream.close()
         yield self.src_stream.write(b"\r\n".join([b"GET /index HTTP/1.1",
                                     b"\r\n"]))
@@ -83,7 +83,7 @@ class Http1LayerTest(AsyncTestCase):
 
     @gen_test
     def test_read_resp_from_dest_failed(self):
-        http_layer_future = self.http_layer.process()
+        http_layer_future = self.http_layer.process_and_return_context()
         yield self.src_stream.write(b"\r\n".join([b"GET /index HTTP/1.1",
                                     b"\r\n"]))
         self.dest_stream.close()
@@ -94,7 +94,7 @@ class Http1LayerTest(AsyncTestCase):
 
     @gen_test
     def test_write_resp_to_src_failed(self):
-        http_layer_future = self.http_layer.process()
+        http_layer_future = self.http_layer.process_and_return_context()
         self.src_stream.write(b"\r\n".join([b"GET /index HTTP/1.1",
                                             b"\r\n"]))
         self.src_stream.close()

--- a/tests/layer/test_socks.py
+++ b/tests/layer/test_socks.py
@@ -100,7 +100,6 @@ class SocksProxyHandlerTest(AsyncTestCase):
         assert port == self.port
 
         dest_stream.close()
-        self.dest_server_stream.close()
         self.client_stream.close()
         self.server_stream.close()
 
@@ -116,10 +115,8 @@ class SocksProxyHandlerTest(AsyncTestCase):
         assert addr_type == 3
         assert host == "localhost"
         assert port == self.port
-        assert not dest_stream.closed()
 
         dest_stream.close()
-        self.dest_server_stream.close()
         self.client_stream.close()
         self.server_stream.close()
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -56,14 +56,14 @@ class LayerManagerTest(AsyncTestCase):
                           config=self.config,
                           port=80)
 
-        context.schema = "http"
+        context.scheme = "http"
         nontls_layer = NonTlsLayer(context)
         layer_constructor = self.layer_manager.next_layer(nontls_layer,
                                                           context)
         layer = layer_constructor(context)
         assert isinstance(layer, Http1Layer)
 
-        context.schema = "https"
+        context.scheme = "https"
         tls_layer = TlsLayer(context)
         layer_constructor = self.layer_manager.next_layer(tls_layer, context)
         layer = layer_constructor(context)

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -4,84 +4,67 @@ from tornado.testing import AsyncTestCase
 
 from microproxy.proxy import LayerManager
 from microproxy.context import Context
-from microproxy.layer import SocksLayer, TransparentLayer, Http1Layer, TlsLayer
+from microproxy.layer import SocksLayer, TransparentLayer, Http1Layer, TlsLayer, NonTlsLayer
 
 
 class LayerManagerTest(AsyncTestCase):
     def setUp(self):
         super(LayerManagerTest, self).setUp()
-
-    def test_get_socks_layer(self):
-        config = {
+        self.config = {
             "mode": "socks",
             "http_port": [],
             "https_port": [],
             "certfile": None,
             "keyfile": None
         }
-        context = Context(src_stream=Mock(),
-                          config=config)
-        layer = LayerManager().start_layer(context)
-        assert isinstance(layer, SocksLayer)
-
-    def test_get_transparent_layer(self):
-        config = {
-            "mode": "transparent",
-            "http_port": [],
-            "https_port": [],
-            "certfile": None,
-            "keyfile": None
-        }
-        context = Context(src_stream=Mock(),
-                          config=config)
-
-        layer = LayerManager().start_layer(context)
-        assert isinstance(layer, TransparentLayer)
+        self.layer_manager = LayerManager(
+            src_stream=Mock(),
+            config=self.config)
 
     def test_get_tls_layer(self):
-        config = {
-            "mode": "socks",
-            "http_port": [],
-            "https_port": [],
-            "certfile": None,
-            "keyfile": None
-        }
         context = Context(src_stream=Mock(),
-                          config=config,
+                          config=self.config,
                           port=443)
 
         socks_layer = SocksLayer(context)
-        layer = LayerManager().next_layer(socks_layer, context)
+        layer_constructor = self.layer_manager.next_layer(socks_layer, context)
+        layer = layer_constructor(context)
         assert isinstance(layer, TlsLayer)
 
         transparent_layer = TransparentLayer(context)
-        layer = LayerManager().next_layer(transparent_layer, context)
+        layer_constructor = self.layer_manager.next_layer(transparent_layer, context)
+        layer = layer_constructor(context)
         assert isinstance(layer, TlsLayer)
 
-    def test_get_http1_layer(self):
-        config = {
-            "mode": "socks",
-            "http_port": [],
-            "https_port": [],
-            "certfile": None,
-            "keyfile": None
-        }
+    def test_get_nontls_layer(self):
         context = Context(src_stream=Mock(),
-                          config=config,
+                          config=self.config,
                           port=80)
 
         socks_layer = SocksLayer(context)
-        layer = LayerManager().next_layer(socks_layer, context)
-        assert isinstance(layer, Http1Layer)
+        layer_constructor = self.layer_manager.next_layer(socks_layer, context)
+        layer = layer_constructor(context)
+        assert isinstance(layer, NonTlsLayer)
 
         transparent_layer = TransparentLayer(context)
-        layer = LayerManager().next_layer(transparent_layer, context)
+        layer_constructor = self.layer_manager.next_layer(transparent_layer, context)
+        layer = layer_constructor(context)
+        assert isinstance(layer, NonTlsLayer)
+
+    def test_get_http1_layer(self):
+        context = Context(src_stream=Mock(),
+                          config=self.config,
+                          port=80)
+
+        context.schema = "http"
+        nontls_layer = NonTlsLayer(context)
+        layer_constructor = self.layer_manager.next_layer(nontls_layer,
+                                                          context)
+        layer = layer_constructor(context)
         assert isinstance(layer, Http1Layer)
 
+        context.schema = "https"
         tls_layer = TlsLayer(context)
-        layer = LayerManager().next_layer(tls_layer, context)
-        assert layer is None
-
-        context.port = 443
-        layer = LayerManager().next_layer(tls_layer, context)
+        layer_constructor = self.layer_manager.next_layer(tls_layer, context)
+        layer = layer_constructor(context)
         assert isinstance(layer, Http1Layer)


### PR DESCRIPTION
This PR add several changes in order to support sni and alpn.
- Implement MicroProxyIOStream and MicroProxySSLIOStream.
- Use pyOpenSSL and service-identity for better ssl control.
- Refactor layer design.
