### PR TITLE
Resolve #145: Add pause resume to resolve detach problem.

### DIFF
--- a/microproxy/layer/proxy/socks.py
+++ b/microproxy/layer/proxy/socks.py
@@ -42,6 +42,7 @@ class SocksLayer(ProxyLayer):
                     raise error
 
                 break
+        self.context.src_stream.pause()
         raise gen.Return(self.context)
 
     def handle_greeting_request(self, event):

--- a/microproxy/layer_manager.py
+++ b/microproxy/layer_manager.py
@@ -1,8 +1,9 @@
 from tornado import gen
 from tornado import iostream
 
-from microproxy.exception import DestStreamClosedError, SrcStreamClosedError, DestNotConnectedError
+from microproxy.iostream import safe_resume_stream
 from microproxy.utils import get_logger
+from microproxy.exception import DestStreamClosedError, SrcStreamClosedError, DestNotConnectedError
 from microproxy.layer import SocksLayer, TransparentLayer, ReplayLayer
 from microproxy.layer import ForwardLayer, TlsLayer, Http1Layer, Http2Layer
 
@@ -60,6 +61,7 @@ def _next_layer(current_layer, context):
     https_ports = [443] + context.config["https_port"]
 
     if isinstance(current_layer, (SocksLayer, TransparentLayer)):
+        safe_resume_stream(context.src_stream)
         if context.port in http_ports:
             context.scheme = "http"
             return Http1Layer(context)


### PR DESCRIPTION
After survey for a while, I still have a hard time finding a more cleaner way to resolve this issue.
- renegotiation is impossible
- openssl bio also only support data channel, no handshake.

It seems like in current pyopenssl implementation, it is impossible to inject the already received buffer to source socket.

So we now only have limited options,
- pause and resume iostream. (This PR implementation)
- created unix named pipe and push the buffer to one read channel and pyopenssl from another channel.

However, currently the pyopenssl can not accept the unix named pipe as the underlying file descriptor.
As a result, maybe currently we still have to stick to the **pause and resume** method.
