### PR TITLE
#164 Adding options to enable/disable verification of insecure cert.

### DIFF
--- a/microproxy/command_line.py
+++ b/microproxy/command_line.py
@@ -102,7 +102,7 @@ def create_proxy_options():
                   option_name="insecure",
                   help_str="Specify the private key file",
                   option_type="string",
-                  default="yes",
+                  default="no",
                   choices=["yes", "no"],
                   cmd_flags="--insecure")
 

--- a/microproxy/command_line.py
+++ b/microproxy/command_line.py
@@ -98,6 +98,21 @@ def create_proxy_options():
                   default="tcp://127.0.0.1:5582",  # Note: Make default to only accept local to access it
                   cmd_flags="--events-channel")
 
+    define_option(option_info=proxy_option_info,
+                  option_name="insecure",
+                  help_str="Specify the private key file",
+                  option_type="string",
+                  default="yes",
+                  choices=["yes", "no"],
+                  cmd_flags="--insecure")
+
+    define_option(option_info=proxy_option_info,
+                  option_name="client_certs",
+                  help_str="Specify the location of trusted ca pem file",
+                  option_type="string",
+                  default="",
+                  cmd_flags="--client-certs")
+
     return proxy_option_info
 
 

--- a/microproxy/layer/application/tls.py
+++ b/microproxy/layer/application/tls.py
@@ -1,5 +1,6 @@
 from copy import copy
 from OpenSSL import SSL
+import certifi
 from service_identity import VerificationError
 from service_identity.pyopenssl import verify_hostname
 from tornado import gen, concurrent
@@ -27,9 +28,15 @@ class TlsLayer(object):
         self._server_hostname = None
 
     def connect_dest(self, support_alpn, hostname):
+        if self.config["client_certs"]:
+            trusted_ca_certs = self.config["client_certs"]
+
+        else:
+            trusted_ca_certs = certifi.where()
+
         dest_context = tls.create_dest_sslcontext(
             insecure=(self.config["insecure"] == "yes"),
-            trusted_ca_certs=self.config["client_certs"],
+            trusted_ca_certs=trusted_ca_certs,
             alpn=support_alpn)
 
         dest_sock = self.context.dest_stream.detach()

--- a/microproxy/layer/proxy/replay.py
+++ b/microproxy/layer/proxy/replay.py
@@ -18,8 +18,9 @@ class ReplayLayer(ProxyLayer):
                 alpn = ["h2"]
             else:
                 alpn = None
+
             dest_stream = yield dest_stream.start_tls(
-                server_side=False, ssl_options=tls.create_dest_sslcontext(alpn))
+                server_side=False, ssl_options=tls.create_dest_sslcontext(alpn=alpn))
 
         self.context.dest_stream = dest_stream
         raise gen.Return(self.context)

--- a/microproxy/test/test_commandline.py
+++ b/microproxy/test/test_commandline.py
@@ -77,6 +77,21 @@ class CommandLineTest(unittest.TestCase):
                       default="tcp://127.0.0.1:5582",  # Note: Make default to only accept local to access it
                       cmd_flags="--events-channel")
 
+        define_option(option_info=proxy_options,
+                      option_name="insecure",
+                      help_str="Specify the private key file",
+                      option_type="string",
+                      default="no",
+                      choices=["yes", "no"],
+                      cmd_flags="--insecure")
+
+        define_option(option_info=proxy_options,
+                      option_name="client_certs",
+                      help_str="Specify the location of trusted ca pem file",
+                      option_type="string",
+                      default="",
+                      cmd_flags="--client-certs")
+
         config = create_proxy_options()
         for options_key in config:
             self.assertIn(options_key, proxy_options)

--- a/mpcertutil.sh
+++ b/mpcertutil.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+
+download_mozilla_certs()
+{
+    local destination_dir
+    destination_dir="${1}"
+    local pem_url
+    pem_url=https://curl.haxx.se/ca/cacert.pem
+
+    echo "Downlading trusted ca from ${pem_url}"
+    wget "${pem_url}" -O "${destination_dir}/cacert.pem"
+
+    if [ $? -ne 0 ]; then
+        echo "Download failed"
+        exit 1
+    fi
+}
+
+get_client_ca()
+{
+    local platform
+    platform=$(uname -s)
+
+    local destination_dir
+    destination_dir="${1}"
+
+    if [ "Linux" == "${platform}" ]; then
+        echo "Checking /etc/ssl/certs/ca-certificates.crt"
+        if [ -s /etc/ssl/certs/ca-certificates.crt ]; then 
+            cp /etc/ssl/certs/ca-certificates.crt "${destination_dir}/cacert.pem"
+        fi
+    elif [ "Darwin" == "${platform}" ]; then
+        echo "Checking /usr/local/etc/openssl/cert.pem"
+        if [ -s /usr/local/etc/openssl/cert.pem ]; then 
+            echo "Using /usr/local/etc/openssl/cert.pem"
+            cp /usr/local/etc/openssl/cert.pem "${destination_dir}/cacert.pem"
+        fi
+    fi
+
+    if [ ! -f "${destination_dir}/cacert.pem" ]; then
+        download_mozilla_certs "${destination_dir}"
+    fi
+}
+
+create_server_ca()
+{
+    local cert_file
+    cert_file="${1}/cert.crt"
+    local key_file
+    key_file="${1}/cert.key"
+    
+    echo "Creating certificate for microProxy"
+    openssl req -new -x509 -days 365 -nodes -out "${cert_file}" -keyout "${key_file}"
+
+    if [ $? -ne 0 ]; then
+        echo "Creating certificate failed"
+        exit 1
+    fi
+}
+
+print_usage()
+{
+    echo "Usage: mpcertutil.sh MODE [PATH]" 
+    echo ""
+    echo "   Create microProxy related certificate to the given PATH."
+    echo "   PATH when not specified, will be the current directory."
+    echo ""
+    echo "example:"
+    echo "   mpcertutil.sh all /var/tmp"
+    echo "   mpcertutil.sh client /var/tmp"
+    echo ""
+    echo "Output MODE:"
+    echo "   all: create both client and server certificate."
+    echo "   client: Check locald trusted ca file. "
+    echo "           If can not find one, download trusted ca file curl."
+    echo "   server: create microproy server cert/key file"
+
+}
+
+if [ $# -lt 1 ]; then
+    echo "mpcertutil.sh require at least one arguments."
+    print_usage
+    exit 1
+fi
+
+if [ $# -eq 1 ]; then
+    download_path=$(pwd)
+else
+    download_path="${2}"
+fi
+
+if [ ! -d "${download_path}" ]; then
+    echo "${download_path} folder not exist"
+    exit 1
+fi
+
+if [ "${1}" == "all" ]; then
+    create_server_ca ${download_path}
+    get_client_ca ${download_path}
+elif [ "${1}" == "client" ]; then
+    get_client_ca ${download_path}
+elif [ "${1}" == "server" ]; then
+    create_server_ca ${download_path}
+else 
+    echo "unknown command"
+    exit 1
+fi
+exit 0

--- a/requirements/proxy.txt
+++ b/requirements/proxy.txt
@@ -3,6 +3,7 @@ pyzmq==15.2.0
 watchdog==0.8.3
 pyOpenSSL==16.0.0
 service-identity==16.0.0
+certifi==2016.8.8
 h2==2.4.0
 
 -e git+https://github.com/chhsiao90/h11.git#egg=h11

--- a/requirements/proxy.txt
+++ b/requirements/proxy.txt
@@ -1,5 +1,5 @@
 tornado==4.3
-pyzmq==15.2.0
+pyzmq==15.4.0
 watchdog==0.8.3
 pyOpenSSL==16.0.0
 service-identity==16.0.0


### PR DESCRIPTION
This PR add two options to proxy server.
- insecure: default to no. When specify, proxy server will not verify the destination certificate.
- client-certs: when insecure is used, user must specify the trusted ca pem file.

As a result, I also add a utility script called **mpcertutil.sh**, which will
- download the trusted ca from curl.
- create the server certificate.
