### PR TITLE
Resolved #151: Add command line options to specify the max width of summary view.

### DIFF
--- a/microproxy/command_line.py
+++ b/microproxy/command_line.py
@@ -139,12 +139,6 @@ def create_tui_viewer_options():
                   default="",
                   cmd_flags="--replay-file")
 
-    define_option(option_info=tui_viewer_option_info,
-                  option_name="max_width",
-                  help_str="Specify a replay script file",
-                  option_type="int",
-                  default=80,
-                  cmd_flags="--max-width")
     return tui_viewer_option_info
 
 

--- a/microproxy/command_line.py
+++ b/microproxy/command_line.py
@@ -138,6 +138,13 @@ def create_tui_viewer_options():
                   option_type="string",
                   default="",
                   cmd_flags="--replay-file")
+
+    define_option(option_info=tui_viewer_option_info,
+                  option_name="max_width",
+                  help_str="Specify a replay script file",
+                  option_type="int",
+                  default=80,
+                  cmd_flags="--max-width")
     return tui_viewer_option_info
 
 

--- a/microproxy/test/test_commandline.py
+++ b/microproxy/test/test_commandline.py
@@ -167,12 +167,12 @@ class CommandLineTest(unittest.TestCase):
                       default="",
                       cmd_flags="--replay-file")
 
-    define_option(option_info=options,
-                  option_name="max_width",
-                  help_str="Specify a replay script file",
-                  option_type="int",
-                  default=80,
-                  cmd_flags="--max-width")
+        define_option(option_info=options,
+                      option_name="max_width",
+                      help_str="Specify a replay script file",
+                      option_type="int",
+                      default=80,
+                      cmd_flags="--max-width")
 
         config = create_tui_viewer_options()
 

--- a/microproxy/test/test_commandline.py
+++ b/microproxy/test/test_commandline.py
@@ -167,13 +167,6 @@ class CommandLineTest(unittest.TestCase):
                       default="",
                       cmd_flags="--replay-file")
 
-        define_option(option_info=options,
-                      option_name="max_width",
-                      help_str="Specify a replay script file",
-                      option_type="int",
-                      default=80,
-                      cmd_flags="--max-width")
-
         config = create_tui_viewer_options()
 
         for option_key in config:

--- a/microproxy/test/test_commandline.py
+++ b/microproxy/test/test_commandline.py
@@ -167,6 +167,13 @@ class CommandLineTest(unittest.TestCase):
                       default="",
                       cmd_flags="--replay-file")
 
+    define_option(option_info=options,
+                  option_name="max_width",
+                  help_str="Specify a replay script file",
+                  option_type="int",
+                  default=80,
+                  cmd_flags="--max-width")
+
         config = create_tui_viewer_options()
 
         for option_key in config:

--- a/microproxy/viewer/tui.py
+++ b/microproxy/viewer/tui.py
@@ -11,7 +11,6 @@ ioloop.install()
 
 
 class Tui(gviewer.BaseDisplayer):
-    SUMMARY_MAX_LENGTH = 100
     PALETTE = [
         ("code ok", "light green", "black", "bold"),
         ("code error", "light red", "black", "bold")
@@ -49,16 +48,21 @@ class Tui(gviewer.BaseDisplayer):
         return ("code error", str(code))
 
     def _fold_path(self, path):
-        return path if len(path) < self.SUMMARY_MAX_LENGTH else path[:self.SUMMARY_MAX_LENGTH - 1] + "..."
+        max_length = self.config["max_width"] - 14
+        return path if len(path) < max_length else path[:max_length - 1] + "..."
 
     def summary(self, message):
+        pretty_path = self._fold_path("{0}://{1}{2}".format(
+            message["scheme"],
+            message["host"],
+            message["path"])
+        )
         return [
             self._code_text_markup(message["response"]["code"]),
-            " {0:7} {1}://{2}{3}".format(
+            " {0:7} {1}".format(
                 message["request"]["method"],
-                message["scheme"],
-                message["host"],
-                self._fold_path(message["path"]))]
+                pretty_path)
+        ]
 
     def get_views(self):
         return [("Request", self.request_view),

--- a/microproxy/viewer/tui.py
+++ b/microproxy/viewer/tui.py
@@ -2,6 +2,7 @@ import zmq
 from zmq.eventloop import ioloop, zmqstream
 import urwid
 import json
+from backports.shutil_get_terminal_size import get_terminal_size
 
 import gviewer
 from microproxy.event import EventClient
@@ -30,6 +31,7 @@ class Tui(gviewer.BaseDisplayer):
         self.formatter = Formatter()
         self.config = config
         self.event_client = EventClient(config["events_channel"])
+        self.terminal_width, _ =  get_terminal_size()
 
     def create_data_store(self):
         return ZmqAsyncDataStore(self.stream.on_recv)
@@ -48,8 +50,8 @@ class Tui(gviewer.BaseDisplayer):
         return ("code error", str(code))
 
     def _fold_path(self, path):
-        max_length = self.config["max_width"] - 14
-        return path if len(path) < max_length else path[:max_length - 1] + "..."
+        max_width = self.terminal_width - 14
+        return path if len(path) < max_width else path[:max_width - 1] + "..."
 
     def summary(self, message):
         pretty_path = self._fold_path("{0}://{1}{2}".format(

--- a/requirements/viewer.txt
+++ b/requirements/viewer.txt
@@ -4,3 +4,4 @@ gviewer==2.1.3
 jsbeautifier==1.6.3
 cssutils==1.0.1
 lxml==3.6.0
+backports.shutil-get-terminal-size==1.0.0


### PR DESCRIPTION
Add new command line option for tui-viewer to specify the max width of summary view.
- max-width: default to 80.
