### PR TITLE
Resolved #173: decode base64 when send replay request

### DIFF
--- a/microproxy/context/http.py
+++ b/microproxy/context/http.py
@@ -24,6 +24,10 @@ class HttpRequest(object):
         json["headers"] = [h for h in self.headers]
         return json
 
+    def __str__(self):
+        return "HttpRequest(version={0}, method={1}, path={2}, headers={3})".format(
+            self.version, self.method, self.path, self.headers)
+
 
 class HttpResponse(object):
     def __init__(self,
@@ -46,6 +50,10 @@ class HttpResponse(object):
         json["body"] = self.body.encode("base64")
         json["headers"] = [h for h in self.headers]
         return json
+
+    def __str__(self):
+        return "HttpResponse(version={0}, code={1}, reason={2}, headers={3})".format(
+            self.version, self.code, self.reason, self.headers)
 
 
 class HttpHeaders(object):

--- a/microproxy/event/replay.py
+++ b/microproxy/event/replay.py
@@ -60,9 +60,15 @@ class ReplayHandler(object):
         return (write_stream, read_stream)
 
     def _send_http1_request(self, stream, context):
+        logger.debug("replay http1 request: {0}".format(context.request))
+        if context.request.body:
+            context.request.body = context.request.body.decode("base64")
         Http1Connection(h11.CLIENT, stream).send_request(context.request)
 
     def _send_http2_request(self, stream, context):
+        logger.debug("replay http2 request: {0}".format(context.request))
+        if context.request.body:
+            context.request.body = context.request.body.decode("base64")
         conn = Http2Connection(stream, client_side=True)
         conn.initiate_connection()
         stream_id = conn.get_next_available_stream_id()

--- a/microproxy/protocol/http1.py
+++ b/microproxy/protocol/http1.py
@@ -120,6 +120,7 @@ class Connection(H11Connection):
             self.io_stream.close()
 
     def send_request(self, request):
+        logger.debug("sent request to {0}: {1}".format(self.conn_type, request))
         self.send(h11.Request(
             method=request.method,
             target=request.path,
@@ -130,6 +131,7 @@ class Connection(H11Connection):
         self.send(h11.EndOfMessage())
 
     def send_response(self, response):
+        logger.debug("sent response to {0}: {1}".format(self.conn_type, response))
         self.send(h11.Response(
             status_code=int(response.code),
             reason=response.reason,
@@ -142,6 +144,7 @@ class Connection(H11Connection):
             self.io_stream.close()
 
     def send_info_response(self, response):
+        logger.debug("sent info response to {0}: {1}".format(self.conn_type, response))
         self.send(h11.InformationalResponse(
             status_code=int(response.code),
             headers=response.headers,

--- a/microproxy/viewer/tui.py
+++ b/microproxy/viewer/tui.py
@@ -148,9 +148,10 @@ class Tui(gviewer.BaseDisplayer):
         widget.set_title(self.summary(message, exported=True))
         parent.notify("replay script export to {0}".format(export_file))
 
-    def replay(self, parent, message, widget, *args, **kwargs):
+    def replay(self, parent, message, *args, **kwargs):
         self.event_client.send_event(message)
-        parent.notify("sent replay event to server")
+        if parent:
+            parent.notify("sent replay event to server")
 
 
 class ZmqAsyncDataStore(gviewer.AsyncDataStore):


### PR DESCRIPTION
Http1 send replay request that forgot to decode base64 so that the Content-Length is not match to  the body length.
Had fixed the problem and add unittest for it.
