### PR TITLE
Resolved #147: Add Server state and related API.

### DIFF
--- a/microproxy/cert.py
+++ b/microproxy/cert.py
@@ -58,18 +58,3 @@ class CertStore(object):
             return self.certs_cache[common_name]
         except KeyError:
             return None
-
-_cert_store = None
-
-
-def init_cert_store(config):
-    global _cert_store
-    _cert_store = CertStore(config)
-
-
-def get_cert_store():
-    global _cert_store
-    if not _cert_store:
-        raise ValueError
-
-    return _cert_store

--- a/microproxy/context/__init__.py
+++ b/microproxy/context/__init__.py
@@ -1,3 +1,4 @@
+from server import ServerContext
 from layer import LayerContext
 from viewer import ViewerContext
 from plugin import PluginContext

--- a/microproxy/context/layer.py
+++ b/microproxy/context/layer.py
@@ -3,17 +3,18 @@ class LayerContext(object):
     LayerContext: Context used to communicate with different layer.
     """
     def __init__(self,
+                 mode,
                  src_stream=None,
                  dest_stream=None,
                  scheme=None,
                  host=None,
-                 port=None,
-                 config=None,
-                 interceptor=None):
+                 port=None):
+        if mode not in ("socks", "transparent", "replay"):
+            raise ValueError("incorrect mode value")
+
+        self.mode = mode
         self.src_stream = src_stream
         self.dest_stream = dest_stream
         self.scheme = scheme
         self.host = host
         self.port = port
-        self.config = config
-        self.interceptor = interceptor

--- a/microproxy/context/server.py
+++ b/microproxy/context/server.py
@@ -1,0 +1,11 @@
+class ServerContext(object):
+    """ServerContext: Context contains server state."""
+    def __init__(self,
+                 io_loop=None,
+                 config=None,
+                 interceptor=None,
+                 cert_store=None):
+        self.io_loop = io_loop
+        self.config = config
+        self.interceptor = interceptor
+        self.cert_store = cert_store

--- a/microproxy/event/manager.py
+++ b/microproxy/event/manager.py
@@ -7,9 +7,9 @@ logger = get_logger(__name__)
 
 
 class EventManager(object):
-    def __init__(self, config, zmq_stream, handler=None):
+    def __init__(self, server_state, zmq_stream, handler=None):
         super(EventManager, self).__init__()
-        self.handler = handler or EventHandler(config)
+        self.handler = handler or EventHandler(server_state)
         self.zmq_stream = zmq_stream
 
     def start(self):
@@ -27,13 +27,12 @@ class EventManager(object):
 
 
 class EventHandler(object):
-    def __init__(self, config):
-        self.config = config
-        self.handler = ReplayHandler(self.config)
+    def __init__(self, server_state):
+        self.handler = ReplayHandler(server_state)
 
     def handle_event(self, event):
         self.handler.handle(event)
 
 
-def start_events_server(config, zmq_stream):
-    EventManager(config, zmq_stream).start()
+def start_events_server(server_state, zmq_stream):
+    EventManager(server_state, zmq_stream).start()

--- a/microproxy/interceptor/__init__.py
+++ b/microproxy/interceptor/__init__.py
@@ -1,18 +1,3 @@
 from msg_publisher import MsgPublisher
+from plugin_manager import PluginManager
 from interceptor import Interceptor
-
-_interceptor = None
-
-
-def init_interceptor(config, msg_publisher=None):
-    global _interceptor
-    if _interceptor:
-        raise ValueError
-    _interceptor = Interceptor(config, msg_publisher=msg_publisher)
-
-
-def get_interceptor():
-    global _interceptor
-    if not _interceptor:
-        raise ValueError
-    return _interceptor

--- a/microproxy/interceptor/interceptor.py
+++ b/microproxy/interceptor/interceptor.py
@@ -1,12 +1,10 @@
-from msg_publisher import MsgPublisher
-from plugin_manager import PluginManager
 from microproxy.context import ViewerContext, PluginContext
 
 
 class Interceptor(object):
-    def __init__(self, config, msg_publisher=None):
-        self.msg_publisher = msg_publisher or MsgPublisher(config)
-        self.plugin_manager = PluginManager(config)
+    def __init__(self, plugin_manager=None, msg_publisher=None):
+        self.msg_publisher = msg_publisher
+        self.plugin_manager = plugin_manager
 
     def request(self, layer_context, request):
         plugin_context = PluginContext(
@@ -16,6 +14,9 @@ class Interceptor(object):
             path=request.path,
             request=request,
             response=None)
+
+        if self.plugin_manager is None:
+            return plugin_context
 
         new_plugin_context = self.plugin_manager.exec_request(plugin_context)
         return new_plugin_context
@@ -29,10 +30,16 @@ class Interceptor(object):
             request=request,
             response=response)
 
+        if self.plugin_manager is None:
+            return plugin_context
+
         new_plugin_context = self.plugin_manager.exec_response(plugin_context)
         return new_plugin_context
 
     def publish(self, layer_context, request, response):
+        if self.msg_publisher is None:
+            return
+
         viewer_context = ViewerContext(
             scheme=layer_context.scheme,
             host=layer_context.host,

--- a/microproxy/layer/application/forward.py
+++ b/microproxy/layer/application/forward.py
@@ -5,7 +5,7 @@ class ForwardLayer(object):
     '''
     ForwardLayer: passing all the src data to destination. Will not intercept anything
     '''
-    def __init__(self, context):
+    def __init__(self, server_state, context):
         super(ForwardLayer, self).__init__()
         self.context = context
         self._future = concurrent.Future()

--- a/microproxy/layer/application/tls.py
+++ b/microproxy/layer/application/tls.py
@@ -7,7 +7,6 @@ from tornado.iostream import StreamClosedError
 
 from microproxy.utils import HAS_ALPN, get_logger
 from microproxy.protocol import tls
-from microproxy.cert import get_cert_store
 from microproxy.exception import (
     DestStreamClosedError, TlsError, ProtocolError)
 
@@ -17,15 +16,15 @@ logger = get_logger(__name__)
 class TlsLayer(object):
     SUPPORT_PROTOCOLS = ["http/1.1", "h2"]
 
-    def __init__(self, context, cert_store=None):
+    def __init__(self, server_state, context):
         super(TlsLayer, self).__init__()
         self.context = copy(context)
-        self.config = self.context.config
-        self.cert_store = cert_store or get_cert_store()
+        self.config = server_state.config
+        self.cert_store = server_state.cert_store
+
         # NOTE: tuple contains (dest_ssl_conn, hostname, alpn_info)
         # Throws exception if failed
         self._dest_stream_future = concurrent.Future()
-        self._server_hostname = None
 
         self.src_conn = tls.ServerConnection(self.context.src_stream)
         self.dest_conn = tls.ClientConnection(self.context.dest_stream)

--- a/microproxy/proxy.py
+++ b/microproxy/proxy.py
@@ -4,28 +4,26 @@ from microproxy.tornado_ext.tcpserver import TCPServer
 from microproxy import layer_manager
 from microproxy.context import LayerContext
 from microproxy.utils import curr_loop, get_logger
-from microproxy.interceptor import get_interceptor
 
 logger = get_logger(__name__)
 
 
 class ProxyServer(TCPServer):
-    def __init__(self, config, **kwargs):
+    def __init__(self, server_state, **kwargs):
         super(ProxyServer, self).__init__(**kwargs)
-        self.config = config
-        self.layer_manager = layer_manager
+        self.server_state = server_state
+        self.config = server_state.config
 
     @gen.coroutine
     def handle_stream(self, stream):
         try:
             initial_context = LayerContext(
-                src_stream=stream,
-                config=self.config,
-                interceptor=get_interceptor())
+                mode=self.config["mode"], src_stream=stream)
 
             logger.debug("Start new layer manager")
-            initial_layer = self.layer_manager.get_first_layer(initial_context)
-            yield self.layer_manager.run_layers(initial_layer, initial_context)
+            initial_layer = layer_manager.get_first_layer(initial_context)
+            yield layer_manager.run_layers(
+                self.server_state, initial_layer, initial_context)
         except Exception as e:
             # NOTE: not handle exception, log it and close the stream
             logger.exception(e)
@@ -38,7 +36,7 @@ class ProxyServer(TCPServer):
                                                           self.config["port"]))
 
 
-def start_tcp_server(config):
+def start_tcp_server(server_state):
     io_loop = curr_loop()
-    server = ProxyServer(config, io_loop=io_loop)
+    server = ProxyServer(server_state, io_loop=io_loop)
     server.start_listener()

--- a/microproxy/server_state.py
+++ b/microproxy/server_state.py
@@ -1,0 +1,35 @@
+"""This module contains two helper function to initialize and get the server state."""
+
+from microproxy.context import ServerContext
+from microproxy.interceptor import Interceptor
+from microproxy.interceptor import MsgPublisher
+from microproxy.interceptor import PluginManager
+from microproxy.cert import CertStore
+
+
+def _init_cert_store(config):
+    return CertStore(config)
+
+
+def _init_interceptor(config, publish_socket):
+    plugin_manager = PluginManager(config)
+    msg_publisher = MsgPublisher(config, zmq_socket=publish_socket)
+    return Interceptor(
+        plugin_manager=plugin_manager, msg_publisher=msg_publisher)
+
+
+def init_server_state(config, publish_socket):
+    """Initialize the ServerContext by config.
+
+    Args:
+        config (dict): The config object pass by user.
+        publish_socket (object): The zmq pub socket for interceptor
+
+    Returns:
+        object: ServerContext.
+    """
+    cert_store = _init_cert_store(config)
+    interceptor = _init_interceptor(config, publish_socket)
+
+    return ServerContext(
+        config=config, interceptor=interceptor, cert_store=cert_store)

--- a/microproxy/test/context/test_layer.py
+++ b/microproxy/test/context/test_layer.py
@@ -1,0 +1,8 @@
+import unittest
+from microproxy.context import LayerContext
+
+
+class TestLayerContext(unittest.TestCase):
+    def test_invalid_mode(self):
+        with self.assertRaises(ValueError):
+            LayerContext(mode="test")

--- a/microproxy/test/layer/test_forward.py
+++ b/microproxy/test/layer/test_forward.py
@@ -35,11 +35,12 @@ class TestForwardLayer(AsyncTestCase):
         self.io_loop.remove_handler(listener)
         listener.close()
 
-        self.context = LayerContext(src_stream=server_streams[0],
+        self.context = LayerContext(mode="socks",
+                                    src_stream=server_streams[0],
                                     dest_stream=client_streams[1])
         self.src_stream = client_streams[0]
         self.dest_stream = server_streams[1]
-        self.forward_layer = ForwardLayer(self.context)
+        self.forward_layer = ForwardLayer(dict(), self.context)
 
     @gen_test
     def test_forward_message(self):

--- a/microproxy/test/layer/test_manager.py
+++ b/microproxy/test/layer/test_manager.py
@@ -4,8 +4,7 @@ from mock import Mock
 
 from tornado import gen, iostream
 from microproxy import layer_manager
-from microproxy.cert import init_cert_store
-from microproxy.context import LayerContext
+from microproxy.context import LayerContext, ServerContext
 from microproxy.layer import SocksLayer, TransparentLayer, ReplayLayer
 from microproxy.layer import TlsLayer, Http1Layer, Http2Layer, ForwardLayer
 from microproxy.exception import DestStreamClosedError, SrcStreamClosedError, DestNotConnectedError
@@ -14,159 +13,137 @@ from microproxy.exception import DestStreamClosedError, SrcStreamClosedError, De
 class TestLayerManager(unittest.TestCase):
     def setUp(self):
         super(TestLayerManager, self).setUp()
-        self.config = {
+        config = {
             "mode": "socks",
             "http_port": [],
             "https_port": [],
             "certfile": "microproxy/test/test.crt",
             "keyfile": "microproxy/test/test.key"
         }
-        init_cert_store(self.config)
+        self.server_state = ServerContext(config=config)
         self.src_stream = Mock()
 
     def test_get_socks_layer(self):
-        context = LayerContext(config=self.config, port=443)
+        context = LayerContext(mode="socks", port=443)
 
         layer = layer_manager.get_first_layer(context)
         self.assertIsInstance(layer, SocksLayer)
 
     @unittest.skipIf('linux' not in sys.platform, "TransparentLayer only in linux")
     def test_get_transparent_layer_linux(self):
-        config = self.config
-        config["mode"] = "transparent"
-
-        context = LayerContext(config=config, port=443)
+        context = LayerContext(mode="transparent", port=443)
         layer = layer_manager.get_first_layer(context)
         self.assertIsInstance(layer, TransparentLayer)
 
     @unittest.skipIf('linux' in sys.platform, "TransparentLayer only in linux")
     def test_get_transparent_layer_non_linux(self):
-        config = self.config
-        config["mode"] = "transparent"
-
-        context = LayerContext(config=config, port=443)
+        context = LayerContext(mode="transparent", port=443)
         with self.assertRaises(NotImplementedError):
             layer_manager.get_first_layer(context)
 
     def test_get_replay_layer(self):
-        config = self.config
-        config["mode"] = "replay"
-
-        context = LayerContext(config=config, port=443)
+        context = LayerContext(mode="replay", port=443)
         layer = layer_manager.get_first_layer(context)
         self.assertIsInstance(layer, ReplayLayer)
 
-    def test_get_layer_error(self):
-        config = self.config
-        config["mode"] = "test"
-
-        context = LayerContext(config=config)
-        with self.assertRaises(ValueError):
-            layer_manager.get_first_layer(context)
-
     def test_get_tls_layer_from_socks(self):
-        context = LayerContext(config=self.config, port=443)
+        context = LayerContext(mode="socks", port=443)
 
         socks_layer = SocksLayer(context)
-        layer = layer_manager._next_layer(socks_layer, context)
+        layer = layer_manager._next_layer(self.server_state, socks_layer, context)
         self.assertIsInstance(layer, TlsLayer)
 
     @unittest.skipIf('linux' not in sys.platform, "TransparentLayer only in linux")
     def test_get_tls_layer_from_transparent(self):
-        context = LayerContext(config=self.config, port=443)
+        context = LayerContext(mode="socks", port=443)
         transparent_layer = TransparentLayer(context)
-        layer = layer_manager._next_layer(transparent_layer, context)
+        layer = layer_manager._next_layer(self.server_state, transparent_layer, context)
         self.assertIsInstance(layer, TlsLayer)
 
     def test_get_http1_layer_from_socks_replay(self):
-        context = LayerContext(config=self.config, port=80)
+        context = LayerContext(mode="socks", port=80)
 
         socks_layer = SocksLayer(context)
-        layer = layer_manager._next_layer(socks_layer, context)
+        layer = layer_manager._next_layer(self.server_state, socks_layer, context)
         self.assertIsInstance(layer, Http1Layer)
 
         context.scheme = "http"
         replay_layer = ReplayLayer(context)
-        layer = layer_manager._next_layer(replay_layer, context)
+        layer = layer_manager._next_layer(self.server_state, replay_layer, context)
         self.assertIsInstance(layer, Http1Layer)
 
         context.scheme = "https"
-        tls_layer = TlsLayer(context)
-        layer = layer_manager._next_layer(tls_layer, context)
+        tls_layer = TlsLayer(self.server_state, context)
+        layer = layer_manager._next_layer(self.server_state, tls_layer, context)
         self.assertIsInstance(layer, Http1Layer)
 
     @unittest.skipIf('linux' not in sys.platform, "TransparentLayer only in linux")
     def test_get_http1_layer_from_transparent(self):
-        context = LayerContext(config=self.config, port=80)
+        context = LayerContext(mode="socks", port=80)
         transparent_layer = TransparentLayer(context)
-        layer = layer_manager._next_layer(transparent_layer, context)
+        layer = layer_manager._next_layer(self.server_state, transparent_layer, context)
         self.assertIsInstance(layer, Http1Layer)
 
     def test_get_http2_layer(self):
-        context = LayerContext(config=self.config, port=443, scheme="h2")
+        context = LayerContext(mode="socks", port=443, scheme="h2")
 
         replay_layer = ReplayLayer(context)
-        layer = layer_manager._next_layer(replay_layer, context)
+        layer = layer_manager._next_layer(self.server_state, replay_layer, context)
         self.assertIsInstance(layer, Http2Layer)
 
-        tls_layer = TlsLayer(context)
-        layer = layer_manager._next_layer(tls_layer, context)
+        tls_layer = TlsLayer(self.server_state, context)
+        layer = layer_manager._next_layer(self.server_state, tls_layer, context)
         self.assertIsInstance(layer, Http2Layer)
 
     def test_get_forward_layer_from_socks_replay(self):
-        context = LayerContext(config=self.config, port=5555)
+        context = LayerContext(mode="socks", port=5555)
 
         socks_layer = SocksLayer(context)
-        layer = layer_manager._next_layer(socks_layer, context)
+        layer = layer_manager._next_layer(self.server_state, socks_layer, context)
         self.assertIsInstance(layer, ForwardLayer)
 
         context.scheme = "test"
         replay_layer = ReplayLayer(context)
-        layer = layer_manager._next_layer(replay_layer, context)
+        layer = layer_manager._next_layer(self.server_state, replay_layer, context)
         self.assertIsInstance(layer, ForwardLayer)
 
         context.scheme = "test"
-        tls_layer = TlsLayer(context)
-        layer = layer_manager._next_layer(tls_layer, context)
+        tls_layer = TlsLayer(self.server_state, context)
+        layer = layer_manager._next_layer(self.server_state, tls_layer, context)
         self.assertIsInstance(layer, ForwardLayer)
 
-    @unittest.skipIf('linux' not in sys.platform, "TransparentLayer only in linux")
     def test_get_forward_layer_from_transparent(self):
-        context = LayerContext(config=self.config, port=5555)
+        context = LayerContext(mode="socks", port=5555)
         transparent_layer = TransparentLayer(context)
-        layer = layer_manager._next_layer(transparent_layer, context)
+        layer = layer_manager._next_layer(self.server_state, transparent_layer, context)
         self.assertIsInstance(layer, ForwardLayer)
 
     def test_handle_layer_error(self):
         context = LayerContext(
-            src_stream=Mock(), config=self.config, port=443, scheme="h2")
+            mode="socks", src_stream=self.src_stream, port=443, scheme="h2")
 
         layer_manager._handle_layer_error(gen.TimeoutError("timeout"), context)
         context.src_stream.close.assert_called_once_with()
 
-        context = LayerContext(
-            src_stream=Mock(), config=self.config, port=443, scheme="h2")
+        context.src_stream.reset_mock()
         layer_manager._handle_layer_error(DestNotConnectedError("stream closed"), context)
         context.src_stream.close.assert_not_called()
 
-        context = LayerContext(
-            src_stream=Mock(), config=self.config, port=443, scheme="h2")
+        context.src_stream.reset_mock()
         layer_manager._handle_layer_error(DestStreamClosedError("stream closed"), context)
         context.src_stream.close.assert_called_once_with()
 
-        context = LayerContext(
-            src_stream=Mock(), config=self.config, port=443, scheme="h2")
+        context.src_stream.reset_mock()
         layer_manager._handle_layer_error(SrcStreamClosedError("stream closed"), context)
         context.src_stream.close.assert_not_called()
 
-        context = LayerContext(
-            src_stream=Mock(), config=self.config, port=443, scheme="h2")
+        context.src_stream.reset_mock()
         layer_manager._handle_layer_error(iostream.StreamClosedError("stream closed"), context)
         context.src_stream.close.assert_called_once_with()
 
     def test_handle_unhandled_layer_error(self):
         context = LayerContext(
-            src_stream=Mock(), config=self.config, port=443, scheme="h2")
+            mode="socks", src_stream=Mock(), port=443, scheme="h2")
         try:
             raise ValueError("stream closed")
         except ValueError as e:

--- a/microproxy/test/layer/test_socks.py
+++ b/microproxy/test/layer/test_socks.py
@@ -44,7 +44,8 @@ class TestSocksProxyHandler(AsyncTestCase):
         self.io_loop.remove_handler(listener)
         listener.close()
 
-        self.context = LayerContext(src_stream=self.server_stream)
+        self.context = LayerContext(
+            mode="socks", src_stream=self.server_stream)
         self.layer = SocksLayer(self.context)
 
         dest_listener, dest_port = bind_unused_port()

--- a/microproxy/test/test_server_state.py
+++ b/microproxy/test/test_server_state.py
@@ -1,0 +1,56 @@
+import unittest
+import mock
+
+from microproxy.server_state import init_server_state, _init_cert_store, _init_interceptor
+
+
+class ServerStateAPITest(unittest.TestCase):
+    def setUp(self):
+        self.config = dict()
+
+    @mock.patch("microproxy.server_state.ServerContext")
+    @mock.patch("microproxy.server_state._init_cert_store")
+    @mock.patch("microproxy.server_state._init_interceptor")
+    def test_init_server_state(self,
+                               mock_init_interceptor,
+                               mock_init_cert_store,
+                               MockServerContext):
+        publish_socket = dict()
+        context = init_server_state(self.config, publish_socket)
+
+        mock_init_cert_store.assert_called_once_with(self.config)
+        mock_init_interceptor.assert_called_once_with(
+            self.config, publish_socket)
+
+        MockServerContext.assert_called_once_with(
+            config=self.config,
+            interceptor=mock_init_interceptor.return_value,
+            cert_store=mock_init_cert_store.return_value)
+        self.assertEqual(context, MockServerContext.return_value)
+
+    @mock.patch("microproxy.server_state.CertStore")
+    def test_init_cert_store(self, MockCertStore):
+        cert_store = _init_cert_store(self.config)
+
+        MockCertStore.assert_called_once_with(self.config)
+        self.assertEqual(cert_store, MockCertStore.return_value)
+
+    @mock.patch("microproxy.server_state.MsgPublisher")
+    @mock.patch("microproxy.server_state.PluginManager")
+    @mock.patch("microproxy.server_state.Interceptor")
+    def test_init_interceptor(self,
+                              MockInterceptor,
+                              MockPluginManager,
+                              MockMsgPublisher):
+
+        publish_socket = dict()
+        interceptor = _init_interceptor(self.config, publish_socket)
+
+        self.assertEqual(interceptor, MockInterceptor.return_value)
+
+        MockPluginManager.assert_called_once_with(self.config)
+        MockMsgPublisher.assert_called_once_with(
+            self.config, zmq_socket=publish_socket)
+        MockInterceptor.assert_called_once_with(
+            plugin_manager=MockPluginManager.return_value,
+            msg_publisher=MockMsgPublisher.return_value)


### PR DESCRIPTION
- Add ServerContext
- Add `init_server_state` and `get_server_state`
- Add server_state parameter when initialize application.layer instance.
- Update unittest.
- Some code cleanup.
