### PR TITLE
[WIP]: Rewrite TLS related code.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,5 @@
 [report]
-omit = microproxy/test/*,microproxy/layer/debug/*
+omit = microproxy/test/*,microproxy/layer/debug/*,microproxy/pyca_tls/*
 exclude_lines =
     pragma: no cover
     def __repr__

--- a/microproxy/event/replay.py
+++ b/microproxy/event/replay.py
@@ -7,7 +7,7 @@ from microproxy.protocol.http1 import Connection as Http1Connection
 from microproxy.protocol.http2 import Connection as Http2Connection
 from microproxy.utils import get_logger, curr_loop
 from microproxy.context import ViewerContext, LayerContext
-from microproxy import layer_manager as default_layer_manager
+from microproxy.layer import manager as default_layer_manager
 
 logger = get_logger(__name__)
 

--- a/microproxy/layer/application/tls.py
+++ b/microproxy/layer/application/tls.py
@@ -1,12 +1,14 @@
+from __future__ import absolute_import
+
 from copy import copy
+import struct
 from OpenSSL import SSL
 import certifi
 from service_identity import VerificationError
-from tornado import gen, concurrent
-from tornado.iostream import StreamClosedError
+from tornado import gen
 
-from microproxy.utils import HAS_ALPN, get_logger
-from microproxy.protocol import tls
+from microproxy.utils import get_logger
+from microproxy.protocol.tls import TlsClientHello, ServerConnection, ClientConnection
 from microproxy.exception import (
     DestStreamClosedError, TlsError, ProtocolError)
 
@@ -14,102 +16,126 @@ logger = get_logger(__name__)
 
 
 class TlsLayer(object):
-    SUPPORT_PROTOCOLS = ["http/1.1", "h2"]
-
     def __init__(self, server_state, context):
         super(TlsLayer, self).__init__()
         self.context = copy(context)
         self.config = server_state.config
         self.cert_store = server_state.cert_store
 
-        # NOTE: tuple contains (dest_ssl_conn, hostname, alpn_info)
-        # Throws exception if failed
-        self._dest_stream_future = concurrent.Future()
+        self.src_conn = ServerConnection(self.context.src_stream)
+        self.dest_conn = ClientConnection(self.context.dest_stream)
 
-        self.src_conn = tls.ServerConnection(self.context.src_stream)
-        self.dest_conn = tls.ClientConnection(self.context.dest_stream)
+    def peek_client_hello(self):
+        client_hello = b""
+        client_hello_size = 1
+        offset = 0
+        while len(client_hello) < client_hello_size:
+            record_header = self.context.src_stream.peek(offset + 5)[offset:]
+            if len(record_header) != 5:
+                raise ProtocolError(
+                    'Expected TLS record, got "{}" instead.'.format(record_header))
 
-    def start_dest_tls(self, support_alpns, hostname):
-        logger.debug("start dest tls handshaking: {0}".format(hostname))
-        trusted_ca_certs = self.config["client_certs"] or certifi.where()
-        try:
-            logger.debug("running dest conn tls handshaking")
-            dest_stream = self.dest_conn.start_tls_blocking(
-                insecure=(self.config["insecure"] == "yes"),
-                trusted_ca_certs=trusted_ca_certs, hostname=hostname,
-                alpns=support_alpns)
-            logger.debug("finish dest conn tls handshake")
-        except Exception as e:
-            logger.debug("dest tls handshaking failed with {0}".format(str(e)))
-            self._dest_stream_future.set_exception(e)
-        else:
-            select_alpn = (dest_stream.fileno().get_alpn_proto_negotiated() or
-                           b"http/1.1")
-            logger.debug("{0}:{1} -> Choose {2} as application protocol".format(
-                self.context.host, self.context.port, select_alpn))
-            self._dest_stream_future.set_result(
-                (dest_stream, hostname, select_alpn))
+            record_size = struct.unpack("!H", record_header[3:])[0] + 5
+            record_body = self.context.src_stream.peek(offset + record_size)[offset + 5:]
+            if len(record_body) != record_size - 5:
+                raise ProtocolError(
+                    "Unexpected EOF in TLS handshake: {}".format(record_body))
 
-    def start_dest_tls_with_alpns(self, src_ssl_conn, src_alpns):
-        """Alpn select callback on source socket
-        that wil also do server side tls handshaking and alpn/sni check
-        """
-        logger.debug("source alpn start: {0}".format(src_alpns))
-        support_alpns = [
-            protocol
-            for protocol in src_alpns
-            if protocol in self.SUPPORT_PROTOCOLS
-        ]
-        hostname = src_ssl_conn.get_servername() or self.context.host
-        self.start_dest_tls(support_alpns, hostname)
+            client_hello += record_body
+            offset += record_size
+            client_hello_size = struct.unpack("!I", b'\x00' + client_hello[1:4])[0] + 4
 
-    def src_info_callback(self, conn, level, ret_code):
-        if not level & SSL.SSL_CB_HANDSHAKE_DONE:
-            return
-        if (HAS_ALPN and conn.get_alpn_proto_negotiated()) or ret_code != 1:
-            return
-        logger.debug("handshake withouth alpn, using http/1.1")
-        self.start_dest_tls(["http/1.1"], conn.get_servername() or self.context.host)
-
-    def resolve_select_alpn(self):
-        _, _, select_alpn = self._dest_stream_future.result()
-        return select_alpn
+        return client_hello
 
     @gen.coroutine
-    def process_and_return_context(self):
+    def start_dest_tls(self, hostname, client_alpns):
+        trusted_ca_certs = self.config["client_certs"] or certifi.where()
+
         try:
+            logger.debug("start dest tls handshaking: {0}".format(hostname))
+            dest_stream = yield self.dest_conn.start_tls(
+                insecure=(self.config["insecure"] == "yes"),
+                trusted_ca_certs=trusted_ca_certs,
+                hostname=hostname, alpns=client_alpns)
+
+        # TODO: tornado_ext.iostream should handle this part.
+        except SSL.SysCallError as e:
+            raise DestStreamClosedError(self, detail="Stream closed when tls Handshaking failed")
+
+        except (SSL.Error, VerificationError) as e:
+            raise TlsError("Tls Handshaking Failed on destination with: ({0}) {1}".format(
+                type(e).__name__, str(e)))
+
+        else:
+            logger.debug(dest_stream.fileno().get_alpn_proto_negotiated())
+            select_alpn = (dest_stream.fileno().get_alpn_proto_negotiated() or
+                           b"http/1.1")
+
+            logger.debug("{0}:{1} -> Choose {2} as application protocol".format(
+                self.context.host, self.context.port, select_alpn))
+            logger.debug("finish dest tls handshake")
+            raise gen.Return((dest_stream, select_alpn))
+
+    @gen.coroutine
+    def start_src_tls(self, hostname, select_alpn):
+        try:
+            logger.debug("start src tls handshaking: {0}".format(hostname))
             src_stream = yield self.src_conn.start_tls(
-                *self.cert_store.get_cert_and_pkey(self.context.host),
-                info_callback=self.src_info_callback,
-                on_alpn=self.start_dest_tls_with_alpns,
-                alpn_resolver=self.resolve_select_alpn)
-        # TODO: SSL.Error may have other error types.
+                *self.cert_store.get_cert_and_pkey(hostname),
+                select_alpn=select_alpn)
+
         except SSL.Error as e:
             raise TlsError("Tls Handshaking Failed on source with: ({0}) {1}".format(
                 type(e).__name__, str(e)))
 
-        try:
-            dest_stream, hostname, alpn_info = yield self._dest_stream_future
-        # TODO: SSL.Error may have other error types.
-        except (SSL.Error, VerificationError) as e:
-            src_stream.close()
-            raise TlsError("Tls Handshaking Failed on destination with: ({0}) {1}".format(
-                type(e).__name__, str(e)))
-        except StreamClosedError as e:
-            src_stream.close()
-            raise DestStreamClosedError(self, detail="Stream closed when tls Handshaking failed")
+        else:
+            logger.debug("finish src tls handshake")
+            raise gen.Return(src_stream)
+
+    def update_layer_context(self,
+                             src_stream,
+                             dest_stream,
+                             hostname,
+                             select_alpn):
 
         self.context.src_stream = src_stream
         self.context.dest_stream = dest_stream
         if hostname:
             self.context.host = hostname
-        if alpn_info == "http/1.1":
+        if select_alpn == "http/1.1":
             self.context.scheme = "https"
-        elif alpn_info == "h2":
+        elif select_alpn == "h2":
             self.context.scheme = "h2"
         else:
-            self.context.src_stream.close()
-            self.context.dest_stream.close()
-            raise ProtocolError("Not supported protocol from alpn: {0}".format(alpn_info))
+            src_stream.close()
+            dest_stream.close()
+            raise ProtocolError("Unsupported alpn protocol: {0}".format(select_alpn))
+
+    @gen.coroutine
+    def process_and_return_context(self):
+        # NOTE: peeking src stream client hello.
+        raw_client_hello = self.peek_client_hello()
+        client_hello = TlsClientHello(raw_client_hello[4:])
+
+        hostname = client_hello.sni or self.context.host
+        try:
+            dest_stream, select_alpn = yield self.start_dest_tls(
+                hostname, client_hello.alpn_protocols)
+        except:
+            if not self.context.src_stream.closed():
+                self.context.src_stream.close()
+            raise
+
+        try:
+            src_stream = yield self.start_src_tls(
+                hostname, select_alpn)
+
+        except:
+            if not dest_stream.closed():
+                dest_stream.close()
+            raise
+
+        self.update_layer_context(
+            src_stream, dest_stream, hostname, select_alpn)
 
         raise gen.Return(self.context)

--- a/microproxy/layer/manager.py
+++ b/microproxy/layer/manager.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from tornado import gen
 from tornado import iostream
 

--- a/microproxy/proxy.py
+++ b/microproxy/proxy.py
@@ -1,7 +1,7 @@
 from tornado import gen
 
 from microproxy.tornado_ext.tcpserver import TCPServer
-from microproxy import layer_manager
+from microproxy.layer import manager as layer_manager
 from microproxy.context import LayerContext
 from microproxy.utils import curr_loop, get_logger
 

--- a/microproxy/pyca_tls/__init__.py
+++ b/microproxy/pyca_tls/__init__.py
@@ -1,0 +1,5 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+from __future__ import absolute_import, division, print_function

--- a/microproxy/pyca_tls/_constructs.py
+++ b/microproxy/pyca_tls/_constructs.py
@@ -1,0 +1,213 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+from __future__ import absolute_import, division, print_function
+
+from construct import (Array, Bytes, Struct, UBInt16, UBInt32, UBInt8, PascalString, Embed, TunnelAdapter, GreedyRange,
+                       Switch, OptionalGreedyRange, Optional)
+
+from .utils import UBInt24
+
+ProtocolVersion = Struct(
+    "version",
+    UBInt8("major"),
+    UBInt8("minor"),
+)
+
+TLSPlaintext = Struct(
+    "TLSPlaintext",
+    UBInt8("type"),
+    ProtocolVersion,
+    UBInt16("length"),  # TODO: Reject packets with length > 2 ** 14
+    Bytes("fragment", lambda ctx: ctx.length),
+)
+
+TLSCompressed = Struct(
+    "TLSCompressed",
+    UBInt8("type"),
+    ProtocolVersion,
+    UBInt16("length"),  # TODO: Reject packets with length > 2 ** 14 + 1024
+    Bytes("fragment", lambda ctx: ctx.length),
+)
+
+TLSCiphertext = Struct(
+    "TLSCiphertext",
+    UBInt8("type"),
+    ProtocolVersion,
+    UBInt16("length"),  # TODO: Reject packets with length > 2 ** 14 + 2048
+    Bytes("fragment", lambda ctx: ctx.length),
+)
+
+Random = Struct(
+    "random",
+    UBInt32("gmt_unix_time"),
+    Bytes("random_bytes", 28),
+)
+
+SessionID = Struct(
+    "session_id",
+    UBInt8("length"),
+    Bytes("session_id", lambda ctx: ctx.length),
+)
+
+CipherSuites = Struct(
+    "cipher_suites",
+    UBInt16("length"),  # TODO: Reject packets of length 0
+    Array(lambda ctx: ctx.length // 2, UBInt16("cipher_suites")),
+)
+
+CompressionMethods = Struct(
+    "compression_methods",
+    UBInt8("length"),  # TODO: Reject packets of length 0
+    Array(lambda ctx: ctx.length, UBInt8("compression_methods")),
+)
+
+ServerName = Struct(
+    "",
+    UBInt8("type"),
+    PascalString("name", length_field=UBInt16("length")),
+)
+
+SNIExtension = Struct(
+    "",
+    TunnelAdapter(
+        PascalString("server_names", length_field=UBInt16("length")),
+        TunnelAdapter(
+            PascalString("", length_field=UBInt16("length")),
+            GreedyRange(ServerName)
+        ),
+    ),
+)
+
+ALPNExtension = Struct(
+    "",
+    TunnelAdapter(
+        PascalString("alpn_protocols", length_field=UBInt16("length")),
+        TunnelAdapter(
+            PascalString("", length_field=UBInt16("length")),
+            GreedyRange(PascalString("name"))
+        ),
+    ),
+)
+
+UnknownExtension = Struct(
+    "",
+    PascalString("bytes", length_field=UBInt16("extensions_length"))
+)
+
+Extension = Struct(
+    "Extension",
+    UBInt16("type"),
+    Embed(
+        Switch(
+            "", lambda ctx: ctx.type,
+            {
+                0x00: SNIExtension,
+                0x10: ALPNExtension
+            },
+            default=UnknownExtension
+        )
+    )
+)
+
+extensions = TunnelAdapter(
+    Optional(PascalString("extensions", length_field=UBInt16("extensions_length"))),
+    OptionalGreedyRange(Extension)
+)
+
+ClientHello = Struct(
+    "ClientHello",
+    ProtocolVersion,
+    Random,
+    SessionID,
+    CipherSuites,
+    CompressionMethods,
+    extensions,
+)
+
+ServerHello = Struct(
+    "ServerHello",
+    ProtocolVersion,
+    Random,
+    SessionID,
+    Bytes("cipher_suite", 2),
+    UBInt8("compression_method"),
+    extensions,
+)
+
+ClientCertificateType = Struct(
+    "certificate_types",
+    UBInt8("length"),  # TODO: Reject packets of length 0
+    Array(lambda ctx: ctx.length, UBInt8("certificate_types")),
+)
+
+SignatureAndHashAlgorithm = Struct(
+    "algorithms",
+    UBInt8("hash"),
+    UBInt8("signature"),
+)
+
+SupportedSignatureAlgorithms = Struct(
+    "supported_signature_algorithms",
+    UBInt16("supported_signature_algorithms_length"),
+    # TODO: Reject packets of length 0
+    Array(
+        lambda ctx: ctx.supported_signature_algorithms_length / 2,
+        SignatureAndHashAlgorithm,
+    ),
+)
+
+DistinguishedName = Struct(
+    "certificate_authorities",
+    UBInt16("length"),
+    Bytes("certificate_authorities", lambda ctx: ctx.length),
+)
+
+CertificateRequest = Struct(
+    "CertificateRequest",
+    ClientCertificateType,
+    SupportedSignatureAlgorithms,
+    DistinguishedName,
+)
+
+ServerDHParams = Struct(
+    "ServerDHParams",
+    UBInt16("dh_p_length"),
+    Bytes("dh_p", lambda ctx: ctx.dh_p_length),
+    UBInt16("dh_g_length"),
+    Bytes("dh_g", lambda ctx: ctx.dh_g_length),
+    UBInt16("dh_Ys_length"),
+    Bytes("dh_Ys", lambda ctx: ctx.dh_Ys_length),
+)
+
+PreMasterSecret = Struct(
+    "pre_master_secret",
+    ProtocolVersion,
+    Bytes("random_bytes", 46),
+)
+
+ASN1Cert = Struct(
+    "ASN1Cert",
+    UBInt32("length"),  # TODO: Reject packets with length not in 1..2^24-1
+    Bytes("asn1_cert", lambda ctx: ctx.length),
+)
+
+Certificate = Struct(
+    "Certificate",  # TODO: Reject packets with length > 2 ** 24 - 1
+    UBInt32("certificates_length"),
+    Bytes("certificates_bytes", lambda ctx: ctx.certificates_length),
+)
+
+Handshake = Struct(
+    "Handshake",
+    UBInt8("msg_type"),
+    UBInt24("length"),
+    Bytes("body", lambda ctx: ctx.length),
+)
+
+Alert = Struct(
+    "Alert",
+    UBInt8("level"),
+    UBInt8("description"),
+)

--- a/microproxy/pyca_tls/utils.py
+++ b/microproxy/pyca_tls/utils.py
@@ -1,0 +1,26 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+from __future__ import absolute_import, division, print_function
+
+import construct
+
+import six
+
+
+class _UBInt24(construct.Adapter):
+    def _encode(self, obj, context):
+        return (
+            six.int2byte((obj & 0xFF0000) >> 16) +
+            six.int2byte((obj & 0x00FF00) >> 8) +
+            six.int2byte(obj & 0x0000FF)
+        )
+
+    def _decode(self, obj, context):
+        obj = bytearray(obj)
+        return (obj[0] << 16 | obj[1] << 8 | obj[2])
+
+
+def UBInt24(name):  # noqa
+    return _UBInt24(construct.Bytes(name, 3))

--- a/microproxy/test/layer/test_forward.py
+++ b/microproxy/test/layer/test_forward.py
@@ -1,59 +1,37 @@
-import socket
+from tornado.testing import gen_test
 
-from tornado.testing import AsyncTestCase, gen_test, bind_unused_port
-from tornado.locks import Semaphore
-from tornado.iostream import IOStream
-from tornado.netutil import add_accept_handler
-
+from microproxy.test.utils import ProxyAsyncTestCase
 from microproxy.context import LayerContext
 from microproxy.layer import ForwardLayer
 
 
-class TestForwardLayer(AsyncTestCase):
+class TestForwardLayer(ProxyAsyncTestCase):
     def setUp(self):
         super(TestForwardLayer, self).setUp()
         self.asyncSetUp()
 
     @gen_test
     def asyncSetUp(self):
-        listener, port = bind_unused_port()
-        semaphore = Semaphore(0)
-        server_streams = []
-
-        def accept_callback(conn, addr):
-            server_stream = IOStream(conn)
-            server_streams.append(server_stream)
-            self.addCleanup(server_stream.close)
-            semaphore.release()
-
-        add_accept_handler(listener, accept_callback)
-        client_streams = [IOStream(socket.socket()), IOStream(socket.socket())]
-        for client_stream in client_streams:
-            self.addCleanup(client_stream.close)
-            yield [client_stream.connect(('127.0.0.1', port)),
-                   semaphore.acquire()]
-        self.io_loop.remove_handler(listener)
-        listener.close()
-
+        self.client_stream, src_stream = yield self.create_iostream_pair()
+        dest_stream, self.server_stream = yield self.create_iostream_pair()
         self.context = LayerContext(mode="socks",
-                                    src_stream=server_streams[0],
-                                    dest_stream=client_streams[1])
-        self.src_stream = client_streams[0]
-        self.dest_stream = server_streams[1]
+                                    src_stream=src_stream,
+                                    dest_stream=dest_stream)
+
         self.forward_layer = ForwardLayer(dict(), self.context)
 
     @gen_test
     def test_forward_message(self):
         self.forward_layer.process_and_return_context()
-        self.src_stream.write(b"aaa\r\n")
-        message = yield self.dest_stream.read_until(b"\r\n")
+        self.client_stream.write(b"aaa\r\n")
+        message = yield self.server_stream.read_until(b"\r\n")
         assert message == b"aaa\r\n"
 
-        self.dest_stream.write(b"bbb\r\n")
-        message = yield self.src_stream.read_until(b"\r\n")
+        self.server_stream.write(b"bbb\r\n")
+        message = yield self.client_stream.read_until(b"\r\n")
         assert message == b"bbb\r\n"
 
-        self.src_stream.close()
-        self.dest_stream.close()
+        self.client_stream.close()
+        self.server_stream.close()
         self.context.src_stream.close()
         self.context.dest_stream.close()

--- a/microproxy/test/layer/test_http1.py
+++ b/microproxy/test/layer/test_http1.py
@@ -1,13 +1,10 @@
-import socket
 from mock import Mock
 import h11
 
-from tornado.testing import AsyncTestCase, gen_test, bind_unused_port
+from tornado.testing import gen_test
 from tornado.gen import coroutine
-from tornado.locks import Semaphore
-from tornado.iostream import IOStream
-from tornado.netutil import add_accept_handler
 
+from microproxy.test.utils import ProxyAsyncTestCase
 from microproxy.context import LayerContext, ServerContext
 from microproxy.layer import Http1Layer
 from microproxy.protocol.http1 import Connection
@@ -15,7 +12,7 @@ from microproxy.context import HttpRequest, HttpResponse, HttpHeaders
 from microproxy.exception import SrcStreamClosedError, DestStreamClosedError
 
 
-class TestHttp1Layer(AsyncTestCase):
+class TestHttp1Layer(ProxyAsyncTestCase):
     def setUp(self):
         super(TestHttp1Layer, self).setUp()
         self.asyncSetUp()
@@ -24,28 +21,12 @@ class TestHttp1Layer(AsyncTestCase):
 
     @gen_test
     def asyncSetUp(self):
-        listener, port = bind_unused_port()
-        semaphore = Semaphore(0)
-        server_streams = []
-
-        def accept_callback(conn, addr):
-            server_stream = IOStream(conn)
-            server_streams.append(server_stream)
-            self.addCleanup(server_stream.close)
-            semaphore.release()
-
-        add_accept_handler(listener, accept_callback)
-        client_streams = [IOStream(socket.socket()), IOStream(socket.socket())]
-        for client_stream in client_streams:
-            self.addCleanup(client_stream.close)
-            yield [client_stream.connect(('127.0.0.1', port)),
-                   semaphore.acquire()]
-        self.io_loop.remove_handler(listener)
-        listener.close()
+        self.client_stream, src_stream = yield self.create_iostream_pair()
+        dest_stream, self.server_stream = yield self.create_iostream_pair()
 
         self.context = LayerContext(mode="socks",
-                                    src_stream=server_streams[0],
-                                    dest_stream=client_streams[1])
+                                    src_stream=src_stream,
+                                    dest_stream=dest_stream)
 
         interceptor = Mock()
         interceptor.publish = Mock(return_value=None)
@@ -53,17 +34,16 @@ class TestHttp1Layer(AsyncTestCase):
         interceptor.response = Mock(return_value=None)
         server_state = ServerContext(interceptor=interceptor)
 
-        self.src_stream = client_streams[0]
-        self.dest_stream = server_streams[1]
         self.http_layer = Http1Layer(server_state, self.context)
 
         self.client_conn = Connection(
-            h11.CLIENT, self.src_stream,
+            h11.CLIENT, self.client_stream,
             on_response=self.record_src_event,
             on_info_response=self.record_src_event,
             on_unhandled=self.ignore_event)
+
         self.server_conn = Connection(
-            h11.SERVER, self.dest_stream,
+            h11.SERVER, self.server_stream,
             on_request=self.record_dest_event,
             on_unhandled=self.ignore_event)
 
@@ -116,8 +96,8 @@ class TestHttp1Layer(AsyncTestCase):
 
         self.assertTrue(http_layer_future.running())
 
-        self.src_stream.close()
-        self.dest_stream.close()
+        self.client_stream.close()
+        self.server_stream.close()
         self.context.src_stream.close()
         self.context.dest_stream.close()
         yield http_layer_future
@@ -125,7 +105,7 @@ class TestHttp1Layer(AsyncTestCase):
     @gen_test
     def test_write_req_to_dest_failed(self):
         http_layer_future = self.http_layer.process_and_return_context()
-        self.dest_stream.close()
+        self.server_stream.close()
         self.client_conn.send_request(HttpRequest(
             version="HTTP/1.1", method="GET", path="/index",
             headers=[("Host", "localhost")]))
@@ -141,7 +121,7 @@ class TestHttp1Layer(AsyncTestCase):
             headers=[("Host", "localhost")]))
 
         self.assertTrue(http_layer_future.running())
-        self.dest_stream.close()
+        self.server_stream.close()
 
         with self.assertRaises(DestStreamClosedError):
             yield http_layer_future
@@ -163,7 +143,7 @@ class TestHttp1Layer(AsyncTestCase):
         self.assertEqual(request.path, "/index")
         self.assertEqual(request.headers, HttpHeaders([("Host", "localhost")]))
 
-        self.src_stream.close()
+        self.client_stream.close()
 
         self.server_conn.send_response(HttpResponse(
             version="HTTP/1.1", code="200", reason="OK",
@@ -267,12 +247,12 @@ class TestHttp1Layer(AsyncTestCase):
         self.assertEqual(request.path, "/index")
         self.assertEqual(request.headers, HttpHeaders([("Host", "localhost")]))
 
-        yield self.dest_stream.write(
+        yield self.server_stream.write(
             (b"HTTP/1.1 200 OK\r\n"
              b"Connection: closed\r\n\r\n"
              b"body"))
 
-        self.dest_stream.close()
+        self.server_stream.close()
 
         yield self.read_until_new_event(self.client_conn, self.src_events)
         self.assertEqual(len(self.src_events), 1)
@@ -307,7 +287,7 @@ class TestHttp1Layer(AsyncTestCase):
         self.assertEqual(request.path, "/chat")
         self.assertEqual(request.headers, HttpHeaders([("Host", "localhost"), ("Upgrade", "websocket")]))
 
-        self.src_stream.close()
+        self.client_stream.close()
 
         self.server_conn.send_info_response(HttpResponse(
             version="HTTP/1.1", code="101", reason="Switching Protocol",
@@ -317,7 +297,7 @@ class TestHttp1Layer(AsyncTestCase):
             yield http_layer_future
 
     def tearDown(self):
-        self.src_stream.close()
-        self.dest_stream.close()
+        self.client_stream.close()
+        self.server_stream.close()
         self.context.src_stream.close()
         self.context.dest_stream.close()

--- a/microproxy/test/layer/test_manager.py
+++ b/microproxy/test/layer/test_manager.py
@@ -3,8 +3,8 @@ import sys
 from mock import Mock
 
 from tornado import gen, iostream
-from microproxy import layer_manager
 from microproxy.context import LayerContext, ServerContext
+from microproxy.layer import manager as layer_manager
 from microproxy.layer import SocksLayer, TransparentLayer, ReplayLayer
 from microproxy.layer import TlsLayer, Http1Layer, Http2Layer, ForwardLayer
 from microproxy.exception import DestStreamClosedError, SrcStreamClosedError, DestNotConnectedError
@@ -112,6 +112,7 @@ class TestLayerManager(unittest.TestCase):
         layer = layer_manager._next_layer(self.server_state, tls_layer, context)
         self.assertIsInstance(layer, ForwardLayer)
 
+    @unittest.skipIf('linux' not in sys.platform, "TransparentLayer only in linux")
     def test_get_forward_layer_from_transparent(self):
         context = LayerContext(mode="socks", port=5555)
         transparent_layer = TransparentLayer(context)

--- a/microproxy/test/layer/test_tls.py
+++ b/microproxy/test/layer/test_tls.py
@@ -1,272 +1,153 @@
 import mock
-import socket
 import unittest
 
 from OpenSSL import SSL
 from service_identity import VerificationError
 from tornado.iostream import StreamClosedError
-from tornado.locks import Event
-from tornado.netutil import add_accept_handler
-from tornado.testing import AsyncTestCase, gen_test, bind_unused_port
+from tornado.testing import gen_test
 
+from microproxy.test.utils import ProxyAsyncTestCase
 from microproxy.cert import CertStore
 from microproxy.context import LayerContext, ServerContext
 from microproxy.exception import DestStreamClosedError, ProtocolError, TlsError
-from microproxy.tornado_ext.iostream import MicroProxyIOStream, MicroProxySSLIOStream
+from microproxy.tornado_ext.iostream import MicroProxySSLIOStream
 from microproxy.layer.application.tls import TlsLayer
-from microproxy.protocol.tls import create_dest_sslcontext
+from microproxy.protocol.tls import create_dest_sslcontext, create_basic_sslcontext
 from microproxy.utils import HAS_ALPN
 
 
-class TestTlsLayer(AsyncTestCase):
+def create_src_sslcontext(cert, priv_key, alpn_callback):
+    ssl_ctx = create_basic_sslcontext()
+    ssl_ctx.use_certificate_file(cert)
+    ssl_ctx.use_privatekey_file(priv_key)
+
+    if alpn_callback and HAS_ALPN:
+        ssl_ctx.set_alpn_select_callback(alpn_callback)
+
+    return ssl_ctx
+
+class TestTlsLayer(ProxyAsyncTestCase):
     def setUp(self):
         super(TestTlsLayer, self).setUp()
         self.asyncSetUp()
 
     @gen_test
     def asyncSetUp(self):
-        listener, port = bind_unused_port()
-        event = Event()
-
-        def accept_callback(conn, addr):
-            self.server_stream = MicroProxyIOStream(conn)
-            event.set()
-
-        add_accept_handler(listener, accept_callback)
-        self.client_stream = MicroProxyIOStream(socket.socket())
-        yield [self.client_stream.connect(('127.0.0.1', port)),
-               event.wait()]
-        self.io_loop.remove_handler(listener)
-        listener.close()
+        self.client_stream, src_stream = yield self.create_iostream_pair()
+        dest_stream, self.server_stream = yield self.create_iostream_pair()
 
         self.config = dict(
             client_certs="microproxy/test/test.crt", insecure="yes")
 
-        context = LayerContext(mode="socks",
-                               src_stream=self.server_stream,
-                               dest_stream=mock.Mock(),
-                               host="127.0.0.1", port=port)
-        self.server_stream = None
-
         cert_store = CertStore(dict(certfile="microproxy/test/test.crt",
                                     keyfile="microproxy/test/test.key"))
         server_state = ServerContext(cert_store=cert_store, config=self.config)
+
+        # src_stream.pause()
+        context = LayerContext(mode="socks",
+                               src_stream=src_stream,
+                               dest_stream=dest_stream,
+                               host="127.0.0.1", port="443")
+
         self.tls_layer = TlsLayer(server_state, context)
 
-        # NOTE: mock dest conn
-        self.tls_dest_stream = mock.Mock()
-        self.tls_dest_stream.fileno = mock.Mock(
-            return_value=self.tls_dest_stream.socket)
-        self.tls_dest_stream.socket.get_alpn_proto_negotiated = mock.Mock(
-            return_value=b"http/1.1")
-        self.dest_conn = mock.Mock()
-        self.dest_conn.start_tls_blocking = mock.Mock(
-            return_value=self.tls_dest_stream)
-        self.tls_layer.dest_conn = self.dest_conn
-
     @gen_test
     @unittest.skipIf(not HAS_ALPN, "only support for env with alpn")
-    def test_success_on_http1(self):
-        client_stream_future = self.client_stream.start_tls(
-            server_side=False,
-            ssl_options=create_dest_sslcontext(
-                insecure=True, alpn=["http/1.1", "h2"]))
-        self.client_stream = None
+    def test_start_dest_tls_with_alpn_http1(self):
+        def alpn_callback(conn, alpns):
+            if "http/1.1" not in alpns:
+                raise ValueError("incorrect alpns")
+            return b"http/1.1"
 
-        ctx_future = self.tls_layer.process_and_return_context()
+        server_stream_future = self.server_stream.start_tls(
+            server_side=True,
+            ssl_options=create_src_sslcontext(
+                "microproxy/test/test.crt", "microproxy/test/test.key",
+                alpn_callback=alpn_callback))
 
-        ctx = yield ctx_future
-        self.assertIsNotNone(ctx)
+        ctx_future = self.tls_layer.start_dest_tls("www.google.com", ["http/1.1"])
 
-        self.server_stream = ctx.src_stream
-        self.assertIsInstance(self.server_stream, MicroProxySSLIOStream)
-        self.assertFalse(self.server_stream.closed())
-        self.assertIs(ctx.dest_stream, self.tls_dest_stream)
-        self.assertEqual(ctx.scheme, "https")
+        dest_stream, alpn = yield ctx_future
+        self.assertIsInstance(dest_stream, MicroProxySSLIOStream)
+        self.assertFalse(dest_stream.closed())
+        self.assertEqual(alpn, "http/1.1")
 
-        # Test on client that handshaking is completed
-        self.client_stream = yield client_stream_future
-        self.assertIsInstance(self.client_stream, MicroProxySSLIOStream)
-        self.assertFalse(self.client_stream.closed())
+        self.server_stream = yield server_stream_future
 
-        # Test on that the connection between client and proxy is worked
-        self.client_stream.write(b"hello")
+        dest_stream.write(b"hello")
         data = yield self.server_stream.read_bytes(5)
         self.assertEqual(data, b"hello")
 
-        self.tls_dest_stream.socket.get_alpn_proto_negotiated.assert_called_with()
-        self.dest_conn.start_tls_blocking.assert_called_with(
-            insecure=True, trusted_ca_certs="microproxy/test/test.crt",
-            hostname="127.0.0.1", alpns=["http/1.1", "h2"])
-
     @gen_test
     @unittest.skipIf(not HAS_ALPN, "only support for env with alpn")
-    def test_success_on_h2(self):
-        self.tls_dest_stream.socket.get_alpn_proto_negotiated = mock.Mock(
-            return_value=b"h2")
+    def test_start_dest_tls_with_alpn_h2(self):
+        def alpn_callback(conn, alpns):
+            if "h2" not in alpns:
+                raise ValueError("incorrect alpns")
+            return b"h2"
 
-        client_stream_future = self.client_stream.start_tls(
-            server_side=False,
-            ssl_options=create_dest_sslcontext(
-                insecure=True, alpn=["http/1.1", "h2"]))
-        self.client_stream = None
+        server_stream_future = self.server_stream.start_tls(
+            server_side=True,
+            ssl_options=create_src_sslcontext(
+                "microproxy/test/test.crt", "microproxy/test/test.key",
+                alpn_callback=alpn_callback))
 
-        ctx_future = self.tls_layer.process_and_return_context()
+        ctx_future = self.tls_layer.start_dest_tls("www.google.com", ["http/1.1", "h2"])
 
-        ctx = yield ctx_future
-        self.assertIsNotNone(ctx)
+        dest_stream, alpn = yield ctx_future
+        self.assertIsInstance(dest_stream, MicroProxySSLIOStream)
+        self.assertFalse(dest_stream.closed())
+        self.assertEqual(alpn, "h2")
 
-        self.server_stream = ctx.src_stream
-        self.assertIsInstance(self.server_stream, MicroProxySSLIOStream)
-        self.assertFalse(self.server_stream.closed())
-        self.assertIs(ctx.dest_stream, self.tls_dest_stream)
-        self.assertEqual(ctx.scheme, "h2")
+        self.server_stream = yield server_stream_future
 
-        # Test on client that handshaking is completed
-        self.client_stream = yield client_stream_future
-        self.assertIsInstance(self.client_stream, MicroProxySSLIOStream)
-        self.assertFalse(self.client_stream.closed())
-
-        # Test on that the connection between client and proxy is worked
-        self.client_stream.write(b"hello")
+        dest_stream.write(b"hello")
         data = yield self.server_stream.read_bytes(5)
         self.assertEqual(data, b"hello")
 
-        self.tls_dest_stream.socket.get_alpn_proto_negotiated.assert_called_with()
-        self.dest_conn.start_tls_blocking.assert_called_with(
-            insecure=True, trusted_ca_certs="microproxy/test/test.crt",
-            hostname="127.0.0.1", alpns=["http/1.1", "h2"])
-
     @gen_test
-    @unittest.skipIf(not HAS_ALPN, "only support for env with alpn")
-    def test_success_on_spdy(self):
-        self.tls_dest_stream.socket.get_alpn_proto_negotiated = mock.Mock(
-            return_value=b"spdy/2")
-
-        client_stream_future = self.client_stream.start_tls(
-            server_side=False,
-            ssl_options=create_dest_sslcontext(
-                insecure=True, alpn=["http/1.1", "spdy/2", "h2"]))
-        self.client_stream = None
-
-        ctx_future = self.tls_layer.process_and_return_context()
-
-        with self.assertRaises(ProtocolError):
-            yield ctx_future
-
-        self.client_stream = yield client_stream_future
-        self.assertTrue(self.client_stream.closed())
-
-    @gen_test
-    def test_success_without_alpn(self):
-        client_stream_future = self.client_stream.start_tls(
-            server_side=False,
-            ssl_options=create_dest_sslcontext(insecure=True))
-        self.client_stream = None
-
-        ctx_future = self.tls_layer.process_and_return_context()
-
-        ctx = yield ctx_future
-        self.assertIsNotNone(ctx)
-
-        self.server_stream = ctx.src_stream
-        self.assertIsInstance(self.server_stream, MicroProxySSLIOStream)
-        self.assertFalse(self.server_stream.closed())
-        self.assertIs(ctx.dest_stream, self.tls_dest_stream)
-        self.assertEqual(ctx.scheme, "https")
-
-        # Test on client that handshaking is completed
-        self.client_stream = yield client_stream_future
-        self.assertIsInstance(self.client_stream, MicroProxySSLIOStream)
-        self.assertFalse(self.client_stream.closed())
-
-        # Test on that the connection between client and proxy is worked
-        self.client_stream.write(b"hello")
-        data = yield self.server_stream.read_bytes(5)
-        self.assertEqual(data, b"hello")
-
-        self.tls_dest_stream.socket.get_alpn_proto_negotiated.assert_called_with()
-        self.dest_conn.start_tls_blocking.assert_called_with(
-            insecure=True, trusted_ca_certs="microproxy/test/test.crt",
-            hostname="127.0.0.1", alpns=["http/1.1"])
-
-    @gen_test
-    def test_dest_handshaking_failed_with_verifycation_error(self):
-        self.dest_conn.start_tls_blocking = mock.Mock(
-            side_effect=VerificationError("error"))
+    def test_start_dest_tls_with_verification_error(self):
         self.config.update(dict(insecure="no"))
 
-        client_stream_future = self.client_stream.start_tls(
-            server_side=False,
-            ssl_options=create_dest_sslcontext(insecure=True))
-        self.client_stream = None
+        def alpn_callback(conn, alpns):
+            return b""
 
-        ctx_future = self.tls_layer.process_and_return_context()
+        server_stream_future = self.server_stream.start_tls(
+            server_side=True,
+            ssl_options=create_src_sslcontext(
+                "microproxy/test/test.crt", "microproxy/test/test.key",
+                alpn_callback=alpn_callback))
 
-        with self.assertRaises(TlsError):
-            yield ctx_future
-
-        self.client_stream = yield client_stream_future
-        self.assertIsNotNone(self.client_stream)
-        self.assertTrue(self.client_stream.closed())
-
-        self.dest_conn.start_tls_blocking.assert_called_with(
-            insecure=False, trusted_ca_certs="microproxy/test/test.crt",
-            hostname="127.0.0.1", alpns=["http/1.1"])
-
-    @gen_test
-    def test_dest_handshaking_failed_with_ssl_error(self):
-        self.dest_conn.start_tls_blocking = mock.Mock(
-            side_effect=SSL.Error)
-
-        client_stream_future = self.client_stream.start_tls(
-            server_side=False,
-            ssl_options=create_dest_sslcontext(insecure=True))
-        self.client_stream = None
-
-        ctx_future = self.tls_layer.process_and_return_context()
+        ctx_future = self.tls_layer.start_dest_tls("www.google.com", [])
 
         with self.assertRaises(TlsError):
-            yield ctx_future
+            dest_stream, alpn = yield ctx_future
 
-        self.client_stream = yield client_stream_future
-        self.assertIsNotNone(self.client_stream)
-        self.assertTrue(self.client_stream.closed())
-
-        self.dest_conn.start_tls_blocking.assert_called_with(
-            insecure=True, trusted_ca_certs="microproxy/test/test.crt",
-            hostname="127.0.0.1", alpns=["http/1.1"])
+        self.server_stream = yield server_stream_future
 
     @gen_test
-    def test_dest_handshaking_failed_with_stream_closed(self):
-        self.dest_conn.start_tls_blocking = mock.Mock(
-            side_effect=StreamClosedError)
+    def test_start_dest_tls_with_ssl_error(self):
+        server_stream_future = self.server_stream.start_tls(
+            server_side=True,
+            ssl_options=create_src_sslcontext(
+                "microproxy/test/test.crt", "microproxy/test/test.key",
+                alpn_callback=None))
 
-        client_stream_future = self.client_stream.start_tls(
-            server_side=False,
-            ssl_options=create_dest_sslcontext(insecure=True))
-        self.client_stream = None
+        self.config.update({"insecure": "no"})
+        ctx_future = self.tls_layer.start_dest_tls("www.google.com", [])
 
-        ctx_future = self.tls_layer.process_and_return_context()
+        with self.assertRaises(TlsError):
+            dest_stream, alpn = yield ctx_future
+
+        self.server_stream = yield server_stream_future
+
+    @gen_test
+    def test_start_dest_tls_with_dest_stream_closed(self):
+        ctx_future = self.tls_layer.start_dest_tls("www.google.com", [])
+        self.server_stream.close()
 
         with self.assertRaises(DestStreamClosedError):
-            yield ctx_future
-
-        self.client_stream = yield client_stream_future
-        self.assertIsNotNone(self.client_stream)
-        self.assertTrue(self.client_stream.closed())
-
-        self.dest_conn.start_tls_blocking.assert_called_with(
-            insecure=True, trusted_ca_certs="microproxy/test/test.crt",
-            hostname="127.0.0.1", alpns=["http/1.1"])
-
-    @gen_test
-    def test_failed_with_client_closed(self):
-        ctx_future = self.tls_layer.process_and_return_context()
-        self.client_stream.close()
-
-        with self.assertRaises(TlsError):
-            yield ctx_future
+            dest_stream, alpn = yield ctx_future
 
     def tearDown(self):
         if self.client_stream and not self.client_stream.closed():

--- a/microproxy/test/protocol/test_http2.py
+++ b/microproxy/test/protocol/test_http2.py
@@ -1,17 +1,14 @@
-import socket
 import mock
 from datetime import timedelta
 from tornado import gen
-from tornado.testing import AsyncTestCase, gen_test, bind_unused_port
-from tornado.locks import Event
-from tornado.iostream import IOStream
-from tornado.netutil import add_accept_handler
+from tornado.testing import gen_test
 
+from microproxy.test.utils import ProxyAsyncTestCase
 from microproxy.protocol.http2 import Connection
 from microproxy.context import HttpRequest, HttpResponse, HttpHeaders
 
 
-class TestConnection(AsyncTestCase):
+class TestConnection(ProxyAsyncTestCase):
     def setUp(self):
         super(TestConnection, self).setUp()
         self.asyncSetUp()
@@ -25,21 +22,9 @@ class TestConnection(AsyncTestCase):
 
     @gen_test
     def asyncSetUp(self):
-        listener, port = bind_unused_port()
-        event = Event()
-
-        def accept_callback(conn, addr):
-            self.server_stream = IOStream(conn)
-            self.addCleanup(self.server_stream.close)
-            event.set()
-
-        add_accept_handler(listener, accept_callback)
-        self.client_stream = IOStream(socket.socket())
+        self.client_stream, self.server_stream = yield self.create_iostream_pair()
         self.addCleanup(self.client_stream.close)
-        yield [self.client_stream.connect(('127.0.0.1', port)),
-               event.wait()]
-        self.io_loop.remove_handler(listener)
-        listener.close()
+        self.addCleanup(self.server_stream.close)
 
     def on_request(self, stream_id, request, priority_updated):
         self.request = (stream_id, request)

--- a/microproxy/test/utils.py
+++ b/microproxy/test/utils.py
@@ -1,0 +1,31 @@
+import socket
+
+from tornado.testing import AsyncTestCase, bind_unused_port
+from tornado.locks import Event
+from tornado.netutil import add_accept_handler
+from tornado.gen import coroutine, Return
+
+from microproxy.tornado_ext.iostream import MicroProxyIOStream
+
+
+class ProxyAsyncTestCase(AsyncTestCase):
+    @coroutine
+    def create_iostream_pair(self):
+        _lock = Event()
+        server_streams = []
+
+        def accept_callback(conn, addr):
+            server_stream = MicroProxyIOStream(conn)
+            server_streams.append(server_stream)
+            # self.addCleanup(server_stream.close)
+            _lock.set()
+
+        listener, port = bind_unused_port()
+        add_accept_handler(listener, accept_callback)
+        client_stream = MicroProxyIOStream(socket.socket())
+        yield [client_stream.connect(('127.0.0.1', port)),
+               _lock.wait()]
+        self.io_loop.remove_handler(listener)
+        listener.close()
+
+        raise Return((client_stream, server_streams[0]))

--- a/requirements/proxy.txt
+++ b/requirements/proxy.txt
@@ -4,6 +4,8 @@ watchdog==0.8.3
 pyOpenSSL==16.0.0
 service-identity==16.0.0
 certifi==2016.8.8
+construct==2.5.3
+six==1.10.0
 h2==2.4.0
 
 -e git+https://github.com/chhsiao90/h11.git#egg=h11


### PR DESCRIPTION
This PR rewrite the tls layer and tls protocol related code.
- Add peek method in tornado_ext/iostream.py
- Use peek method to get alpn and hostname.
- Destination start_tls is now non-blocking.
- Remove start_tls_block since it's now useless.
- Porting pyca tls module from mitmproxy.
- Port peek_client_hello from mitmproxy.
