### PR TITLE
Remove pause/resume methods from microproxy iostream.

### DIFF
--- a/microproxy/layer/proxy/socks.py
+++ b/microproxy/layer/proxy/socks.py
@@ -79,9 +79,6 @@ class SocksLayer(ProxyLayer):
             yield self.send_event_to_src_conn(Response(
                 socks_version, RESP_STATUS["SUCCESS"],
                 event.atyp, event.addr, event.port))
-            # NOTE: currently, we need pause src stream to prevent that we cannot detach the socket
-            # to do tls handshaking
-            self.context.src_stream.pause()
             raise gen.Return((dest_stream, event.addr, event.port))
 
     @gen.coroutine

--- a/microproxy/layer_manager.py
+++ b/microproxy/layer_manager.py
@@ -1,7 +1,6 @@
 from tornado import gen
 from tornado import iostream
 
-from microproxy.tornado_ext.iostream import safe_resume_stream
 from microproxy.utils import get_logger
 from microproxy.exception import DestStreamClosedError, SrcStreamClosedError, DestNotConnectedError
 from microproxy.layer import SocksLayer, TransparentLayer, ReplayLayer
@@ -73,7 +72,6 @@ def _next_layer(server_state, current_layer, context):
     https_ports = [443] + config["https_port"]
 
     if isinstance(current_layer, (SocksLayer, TransparentLayer)):
-        safe_resume_stream(context.src_stream)
         if context.port in http_ports:
             context.scheme = "http"
             return Http1Layer(server_state, context)
@@ -100,4 +98,4 @@ def _next_layer(server_state, current_layer, context):
 
     if isinstance(current_layer, Http1Layer):
         if context.scheme == "websocket":
-            return ForwardLayer(context)
+            return ForwardLayer(server_state, context)


### PR DESCRIPTION
The root cause of "IOStream is not Idle" when calling start_tls is that current tornado iostream implementation will recv the data to buffer even when the iostream state is not reading. As a result, when some other code yield there is a posibility that the handle_read will be called.

Thie PR change the behavior of this part. When the iostream is not in reading state, we will not handle_read even when event is happened until the client called read_xxx related code.
