### PR TITLE
Refine config #137

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,3 +6,11 @@ lint:
 
 coverage:
 	@coverage run --source=microproxy -m unittest discover
+
+install:
+	pip install -U --no-deps .
+
+install-all:
+	pip install -U .
+	pip install -U .[viewer]
+	pip install -U .[dev]

--- a/application.cfg
+++ b/application.cfg
@@ -1,24 +1,14 @@
 [proxy]
-# proxy general settings
 mode=socks
 host=127.0.0.1
 port=5580
 
-# define addtional http/https port
 http.port=5000
 https.port=5001
-
-# Viewer Channel
-viewer.channel=tcp://*:5581
 
 certfile=/tmp/cert.crt
 keyfile=/tmp/cert.key
 
-[console-viewer]
-proxy.host=tcp://127.0.0.1
-viewer.port=5581
-events.port=5582
-
-[tui-viewer]
-viewer.channel=tcp://127.0.0.1:5581
-events.channel=tcp://127.0.0.1:5582
+[channel]
+viewer=tcp://127.0.0.1:5581
+events=tcp://127.0.0.1:5582

--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-from microproxy.command_line import main
+from microproxy.command_line import mpserver
 
 if __name__ == '__main__':
-    main()
+    mpserver()

--- a/microproxy/command_line.py
+++ b/microproxy/command_line.py
@@ -1,29 +1,4 @@
-from microproxy.config import parse_config, define_option, define_section
-
-
-def create_options():
-
-    config_field_info = {}
-
-    proxy_option_info = create_proxy_options()
-    define_section(config_field_info=config_field_info,
-                   section="proxy",
-                   option_info=proxy_option_info,
-                   help_str="Open microproxy service")
-
-    console_viewer_option_info = create_console_viewer_options()
-    define_section(config_field_info=config_field_info,
-                   section="console-viewer",
-                   option_info=console_viewer_option_info,
-                   help_str="Open console viewer")
-
-    tui_viewer_option_info = create_tui_viewer_options()
-    define_section(config_field_info=config_field_info,
-                   section="tui-viewer",
-                   option_info=tui_viewer_option_info,
-                   help_str="Open tui viewer")
-
-    return config_field_info
+from microproxy.config import parse_config, define_option
 
 
 def create_proxy_options():
@@ -32,86 +7,94 @@ def create_proxy_options():
                   option_name="host",
                   help_str="Specify the proxy host",
                   default="127.0.0.1",
-                  option_type="string",
-                  cmd_flags="--host")
+                  option_type="str",
+                  cmd_flags="--host",
+                  config_file_flags="proxy:host")
 
     define_option(option_info=proxy_option_info,
                   option_name="port",
                   help_str="Specify the proxy listening port",
                   default="5580",
                   option_type="int",
-                  cmd_flags="--port")
+                  cmd_flags="--port",
+                  config_file_flags="proxy:port")
 
     define_option(option_info=proxy_option_info,
                   option_name="mode",
                   help_str="Speficy the proxy mode, currently support socks proxy and transparent proxy",
-                  option_type="string",
+                  option_type="str",
                   cmd_flags="--mode",
+                  config_file_flags="proxy:mode",
                   choices=["socks", "transparent"])
 
     define_option(option_info=proxy_option_info,
                   option_name="http_port",
                   help_str="Add additional http port",
                   default="",
-                  option_type="list",
+                  option_type="list:int",
                   cmd_flags="--http-port",
-                  list_type="int")
+                  config_file_flags="proxy:http.port"
+                  )
 
     define_option(option_info=proxy_option_info,
                   option_name="https_port",
                   help_str="Add additional https port",
                   default="",
-                  option_type="list",
+                  option_type="list:int",
                   cmd_flags="--https-port",
-                  list_type="int")
+                  config_file_flags="proxy:https.port")
+
+    define_option(option_info=proxy_option_info,
+                  option_name="certfile",
+                  help_str="Specify the certificate file",
+                  option_type="str",
+                  cmd_flags="--cert-file",
+                  config_file_flags="proxy:certfile")
+
+    define_option(option_info=proxy_option_info,
+                  option_name="keyfile",
+                  help_str="Specify the private key file",
+                  option_type="str",
+                  cmd_flags="--key-file",
+                  config_file_flags="proxy:keyfile")
+
+    define_option(option_info=proxy_option_info,
+                  option_name="viewer_channel",
+                  help_str="Specify the viewer channel. ex. tcp://*:5581",
+                  option_type="str",
+                  cmd_flags="--viewer-channel",
+                  config_file_flags="channel:viewer")
+
+    define_option(option_info=proxy_option_info,
+                  option_name="events_channel",
+                  help_str="Specify the events channel. ex. tcp://*:5582",
+                  option_type="str",
+                  default="tcp://127.0.0.1:5582",  # Note: Make default to only accept local to access it
+                  cmd_flags="--events-channel",
+                  config_file_flags="channel:events")
 
     define_option(option_info=proxy_option_info,
                   option_name="plugins",
                   help_str="Load plugins",
                   default="",
-                  option_type="list",
+                  option_type="list:str",
                   cmd_flags="--plugins",
-                  list_type="string")
-
-    define_option(option_info=proxy_option_info,
-                  option_name="viewer_channel",
-                  help_str="Specify the viewer channel. ex. tcp://*:5581",
-                  option_type="string",
-                  cmd_flags="--viewer-channel")
-
-    define_option(option_info=proxy_option_info,
-                  option_name="certfile",
-                  help_str="Specify the certificate file",
-                  option_type="string",
-                  cmd_flags="--cert-file")
-
-    define_option(option_info=proxy_option_info,
-                  option_name="keyfile",
-                  help_str="Specify the private key file",
-                  option_type="string",
-                  cmd_flags="--key-file")
-
-    define_option(option_info=proxy_option_info,
-                  option_name="events_channel",
-                  help_str="Specify the events channel. ex. tcp://*:5582",
-                  option_type="string",
-                  default="tcp://127.0.0.1:5582",  # Note: Make default to only accept local to access it
-                  cmd_flags="--events-channel")
-
-    define_option(option_info=proxy_option_info,
-                  option_name="insecure",
-                  help_str="Specify the private key file",
-                  option_type="string",
-                  default="no",
-                  choices=["yes", "no"],
-                  cmd_flags="--insecure")
+                  config_file_flags="advanced:plugins")
 
     define_option(option_info=proxy_option_info,
                   option_name="client_certs",
                   help_str="Specify the location of trusted ca pem file",
-                  option_type="string",
+                  option_type="str",
                   default="",
-                  cmd_flags="--client-certs")
+                  cmd_flags="--client-certs",
+                  config_file_flags="advanced:client.certs")
+
+    define_option(option_info=proxy_option_info,
+                  option_name="insecure",
+                  help_str="This option make the proxy connect to inscure SSL connections.",
+                  option_type="bool",
+                  default=False,
+                  cmd_flags=["--insecure", "-k"])
 
     return proxy_option_info
 
@@ -122,19 +105,21 @@ def create_tui_viewer_options():
     define_option(option_info=tui_viewer_option_info,
                   option_name="viewer_channel",
                   help_str="Specify the viewer channel. ex. tcp://127.0.0.1:5581",
-                  option_type="string",
-                  cmd_flags="--viewer-channel")
+                  option_type="str",
+                  cmd_flags="--viewer-channel",
+                  config_file_flags="channel:viewer")
 
     define_option(option_info=tui_viewer_option_info,
                   option_name="events_channel",
                   help_str="Specify the events channel. ex. tcp://127.0.0.1:5582",
-                  option_type="string",
-                  cmd_flags="--events-channel")
+                  option_type="str",
+                  cmd_flags="--events-channel",
+                  config_file_flags="channel:events")
 
     define_option(option_info=tui_viewer_option_info,
                   option_name="replay_file",
                   help_str="Specify a replay script file",
-                  option_type="string",
+                  option_type="str",
                   default="",
                   cmd_flags="--replay-file")
 
@@ -147,25 +132,28 @@ def create_console_viewer_options():
     define_option(option_info=console_viewer_option_info,
                   option_name="proxy_host",
                   help_str="Specify the proxy host. ex. tcp://127.0.0.1",
-                  option_type="string",
-                  cmd_flags="--proxy-host")
+                  option_type="str",
+                  cmd_flags="--proxy-host",
+                  config_file_flags="channel:host")
 
     define_option(option_info=console_viewer_option_info,
                   option_name="viewer_port",
                   help_str="Specify the viewer channel port. ex. 5581",
                   option_type="int",
-                  cmd_flags="--viewer-channel-port")
+                  cmd_flags="--viewer-channel-port",
+                  config_file_flags="channel:viewer.port")
 
     define_option(option_info=console_viewer_option_info,
                   option_name="events_port",
                   help_str="Specify the events channel port. ex. 5582",
                   option_type="int",
-                  cmd_flags="--events-channel-port")
+                  cmd_flags="--events-channel-port",
+                  config_file_flags="channel:events.port")
 
     define_option(option_info=console_viewer_option_info,
                   option_name="verbose_level",
                   help_str="Specify verbose level. (header, body, all)",
-                  option_type="string",
+                  option_type="str",
                   cmd_flags="--verbose-level",
                   default="status",
                   choices=["status", "header", "body", "all"])
@@ -173,14 +161,14 @@ def create_console_viewer_options():
     define_option(option_info=console_viewer_option_info,
                   option_name="replay_file",
                   help_str="Specify replay file",
-                  option_type="string",
+                  option_type="str",
                   default="",
                   cmd_flags="--replay-file")
 
     define_option(option_info=console_viewer_option_info,
                   option_name="dump_file",
                   help_str="Specify dump file",
-                  option_type="string",
+                  option_type="str",
                   default="",
                   cmd_flags="--dump-file")
 
@@ -216,23 +204,28 @@ def run_proxy_mode(config):
         logger.info("bye")
 
 
-def main():  # pragma: no cover
+def mpserver():  # pragma: no cover
     # NOTE: logger must start before everything else
     from microproxy.utils import init_system_logger
     init_system_logger()
 
-    config_field_info = create_options()
+    config_field_info = create_proxy_options()
     config = parse_config(config_field_info)
 
-    if config["command_type"] == "proxy":
-        run_proxy_mode(config)
-    elif config["command_type"] == "console-viewer":
-        from microproxy.viewer import console as console_viewer
-        console_viewer.start(config)
-    elif config["command_type"] == "tui-viewer":
-        from microproxy.viewer import tui as tui_viewer
-        tui_viewer.start(config)
+    run_proxy_mode(config)
 
 
-if __name__ == '__main__':
-    main()
+def mpdump(): # pragma: no cover
+    from microproxy.viewer import console as console_viewer
+
+    config_field_info = create_console_viewer_options()
+    config = parse_config(config_field_info)
+    console_viewer.start(config)
+
+
+def mptui(): # pragma: no cover
+    from microproxy.viewer import tui as tui_viewer
+
+    config_field_info = create_tui_viewer_options()
+    config = parse_config(config_field_info)
+    tui_viewer.start(config)

--- a/microproxy/layer/application/tls.py
+++ b/microproxy/layer/application/tls.py
@@ -54,7 +54,7 @@ class TlsLayer(object):
         try:
             logger.debug("start dest tls handshaking: {0}".format(hostname))
             dest_stream = yield self.dest_conn.start_tls(
-                insecure=(self.config["insecure"] == "yes"),
+                insecure=self.config["insecure"],
                 trusted_ca_certs=trusted_ca_certs,
                 hostname=hostname, alpns=client_alpns)
 

--- a/microproxy/test/layer/test_tls.py
+++ b/microproxy/test/layer/test_tls.py
@@ -37,7 +37,7 @@ class TestTlsLayer(ProxyAsyncTestCase):
         dest_stream, self.server_stream = yield self.create_iostream_pair()
 
         self.config = dict(
-            client_certs="microproxy/test/test.crt", insecure="yes")
+            client_certs="microproxy/test/test.crt", insecure=True)
 
         cert_store = CertStore(dict(certfile="microproxy/test/test.crt",
                                     keyfile="microproxy/test/test.key"))
@@ -107,7 +107,7 @@ class TestTlsLayer(ProxyAsyncTestCase):
 
     @gen_test
     def test_start_dest_tls_with_verification_error(self):
-        self.config.update(dict(insecure="no"))
+        self.config.update(dict(insecure=False))
 
         def alpn_callback(conn, alpns):
             return b""
@@ -133,7 +133,7 @@ class TestTlsLayer(ProxyAsyncTestCase):
                 "microproxy/test/test.crt", "microproxy/test/test.key",
                 alpn_callback=None))
 
-        self.config.update({"insecure": "no"})
+        self.config.update({"insecure": False})
         ctx_future = self.tls_layer.start_dest_tls("www.google.com", [])
 
         with self.assertRaises(TlsError):

--- a/microproxy/test/test_commandline.py
+++ b/microproxy/test/test_commandline.py
@@ -6,168 +6,180 @@ from microproxy.config import define_option
 
 class CommandLineTest(unittest.TestCase):
     def test_proxy_command(self):
-        proxy_options = {}
-        define_option(option_info=proxy_options,
+        proxy_option_info = {}
+        define_option(option_info=proxy_option_info,
                       option_name="host",
                       help_str="Specify the proxy host",
                       default="127.0.0.1",
-                      option_type="string",
-                      cmd_flags="--host")
+                      option_type="str",
+                      cmd_flags="--host",
+                      config_file_flags="proxy:host")
 
-        define_option(option_info=proxy_options,
+        define_option(option_info=proxy_option_info,
                       option_name="port",
                       help_str="Specify the proxy listening port",
                       default="5580",
                       option_type="int",
-                      cmd_flags="--port")
+                      cmd_flags="--port",
+                      config_file_flags="proxy:port")
 
-        define_option(option_info=proxy_options,
+        define_option(option_info=proxy_option_info,
                       option_name="mode",
                       help_str="Speficy the proxy mode, currently support socks proxy and transparent proxy",
-                      option_type="string",
+                      option_type="str",
                       cmd_flags="--mode",
+                      config_file_flags="proxy:mode",
                       choices=["socks", "transparent"])
 
-        define_option(option_info=proxy_options,
+        define_option(option_info=proxy_option_info,
                       option_name="http_port",
                       help_str="Add additional http port",
                       default="",
-                      option_type="list",
+                      option_type="list:int",
                       cmd_flags="--http-port",
-                      list_type="int")
+                      config_file_flags="proxy:http.port"
+                      )
 
-        define_option(option_info=proxy_options,
+        define_option(option_info=proxy_option_info,
                       option_name="https_port",
                       help_str="Add additional https port",
                       default="",
-                      option_type="list",
+                      option_type="list:int",
                       cmd_flags="--https-port",
-                      list_type="int")
+                      config_file_flags="proxy:https.port")
 
-        define_option(option_info=proxy_options,
+        define_option(option_info=proxy_option_info,
+                      option_name="certfile",
+                      help_str="Specify the certificate file",
+                      option_type="str",
+                      cmd_flags="--cert-file",
+                      config_file_flags="proxy:certfile")
+
+        define_option(option_info=proxy_option_info,
+                      option_name="keyfile",
+                      help_str="Specify the private key file",
+                      option_type="str",
+                      cmd_flags="--key-file",
+                      config_file_flags="proxy:keyfile")
+
+        define_option(option_info=proxy_option_info,
+                      option_name="viewer_channel",
+                      help_str="Specify the viewer channel. ex. tcp://*:5581",
+                      option_type="str",
+                      cmd_flags="--viewer-channel",
+                      config_file_flags="channel:viewer")
+
+        define_option(option_info=proxy_option_info,
+                      option_name="events_channel",
+                      help_str="Specify the events channel. ex. tcp://*:5582",
+                      option_type="str",
+                      default="tcp://127.0.0.1:5582",  # Note: Make default to only accept local to access it
+                      cmd_flags="--events-channel",
+                      config_file_flags="channel:events")
+
+        define_option(option_info=proxy_option_info,
                       option_name="plugins",
                       help_str="Load plugins",
                       default="",
-                      option_type="list",
+                      option_type="list:str",
                       cmd_flags="--plugins",
-                      list_type="string")
+                      config_file_flags="advanced:plugins")
 
-        define_option(option_info=proxy_options,
-                      option_name="viewer_channel",
-                      help_str="Specify the viewer channel. ex. tcp://*:5581",
-                      option_type="string",
-                      cmd_flags="--viewer-channel")
-
-        define_option(option_info=proxy_options,
-                      option_name="certfile",
-                      help_str="Specify the certificate file",
-                      option_type="string",
-                      cmd_flags="--cert-file")
-
-        define_option(option_info=proxy_options,
-                      option_name="keyfile",
-                      help_str="Specify the private key file",
-                      option_type="string",
-                      cmd_flags="--key-file")
-
-        define_option(option_info=proxy_options,
-                      option_name="events_channel",
-                      help_str="Specify the events channel. ex. tcp://*:5582",
-                      option_type="string",
-                      default="tcp://127.0.0.1:5582",  # Note: Make default to only accept local to access it
-                      cmd_flags="--events-channel")
-
-        define_option(option_info=proxy_options,
-                      option_name="insecure",
-                      help_str="Specify the private key file",
-                      option_type="string",
-                      default="no",
-                      choices=["yes", "no"],
-                      cmd_flags="--insecure")
-
-        define_option(option_info=proxy_options,
+        define_option(option_info=proxy_option_info,
                       option_name="client_certs",
                       help_str="Specify the location of trusted ca pem file",
-                      option_type="string",
+                      option_type="str",
                       default="",
-                      cmd_flags="--client-certs")
+                      cmd_flags="--client-certs",
+                      config_file_flags="advanced:client.certs")
+
+        define_option(option_info=proxy_option_info,
+                      option_name="insecure",
+                      help_str="This option make the proxy connect to inscure SSL connections.",
+                      option_type="bool",
+                      default=False,
+                      cmd_flags=["--insecure", "-k"])
 
         config = create_proxy_options()
         for options_key in config:
-            self.assertIn(options_key, proxy_options)
+            self.assertIn(options_key, proxy_option_info)
 
     def test_console_command(self):
-        options = {}
+        console_viewer_option_info = {}
 
-        define_option(option_info=options,
+        define_option(option_info=console_viewer_option_info,
                       option_name="proxy_host",
                       help_str="Specify the proxy host. ex. tcp://127.0.0.1",
-                      option_type="string",
-                      cmd_flags="--proxy-host")
+                      option_type="str",
+                      cmd_flags="--proxy-host",
+                      config_file_flags="channel:host")
 
-        define_option(option_info=options,
+        define_option(option_info=console_viewer_option_info,
                       option_name="viewer_port",
                       help_str="Specify the viewer channel port. ex. 5581",
                       option_type="int",
-                      cmd_flags="--viewer-channel-port")
+                      cmd_flags="--viewer-channel-port",
+                      config_file_flags="channel:viewer.port")
 
-        define_option(option_info=options,
+        define_option(option_info=console_viewer_option_info,
                       option_name="events_port",
                       help_str="Specify the events channel port. ex. 5582",
                       option_type="int",
-                      cmd_flags="--events-channel-port")
+                      cmd_flags="--events-channel-port",
+                      config_file_flags="channel:events.port")
 
-        define_option(option_info=options,
+        define_option(option_info=console_viewer_option_info,
                       option_name="verbose_level",
                       help_str="Specify verbose level. (header, body, all)",
-                      option_type="string",
+                      option_type="str",
                       cmd_flags="--verbose-level",
                       default="status",
                       choices=["status", "header", "body", "all"])
 
-        define_option(option_info=options,
+        define_option(option_info=console_viewer_option_info,
                       option_name="replay_file",
                       help_str="Specify replay file",
-                      option_type="string",
+                      option_type="str",
                       default="",
                       cmd_flags="--replay-file")
 
-        define_option(option_info=options,
+        define_option(option_info=console_viewer_option_info,
                       option_name="dump_file",
                       help_str="Specify dump file",
-                      option_type="string",
+                      option_type="str",
                       default="",
                       cmd_flags="--dump-file")
 
         config = create_console_viewer_options()
 
         for option_key in config:
-            self.assertIn(option_key, options)
+            self.assertIn(option_key, console_viewer_option_info)
 
     def test_tui_command(self):
-        options = {}
+        tui_viewer_option_info = {}
 
-        define_option(option_info=options,
+        define_option(option_info=tui_viewer_option_info,
                       option_name="viewer_channel",
                       help_str="Specify the viewer channel. ex. tcp://127.0.0.1:5581",
-                      option_type="string",
-                      cmd_flags="--viewer-channel")
+                      option_type="str",
+                      cmd_flags="--viewer-channel",
+                      config_file_flags="channel:viewer")
 
-        define_option(option_info=options,
+        define_option(option_info=tui_viewer_option_info,
                       option_name="events_channel",
                       help_str="Specify the events channel. ex. tcp://127.0.0.1:5582",
-                      option_type="string",
-                      default="tcp://127.0.0.1:5582",
-                      cmd_flags="--events-channel")
+                      option_type="str",
+                      cmd_flags="--events-channel",
+                      config_file_flags="channel:events")
 
-        define_option(option_info=options,
+        define_option(option_info=tui_viewer_option_info,
                       option_name="replay_file",
                       help_str="Specify a replay script file",
-                      option_type="string",
+                      option_type="str",
                       default="",
                       cmd_flags="--replay-file")
 
         config = create_tui_viewer_options()
 
         for option_key in config:
-            self.assertIn(option_key, options)
+            self.assertIn(option_key, tui_viewer_option_info)

--- a/microproxy/test/test_config.py
+++ b/microproxy/test/test_config.py
@@ -36,36 +36,42 @@ class TestDefineSection(unittest.TestCase):
 
 
 class TestDefineOption(unittest.TestCase):
-    def test_non_list_type_option_without_default(self):
+    def test_str_type_option_without_default(self):
         config_info = {}
         define_option(option_info=config_info,
                       option_name="test",
                       help_str="test is a help",
-                      option_type="string")
+                      option_type="str",
+                      cmd_flags="--test")
 
         self.assertIn("test", config_info)
         self.assertEqual(config_info["test"]["help"], "test is a help")
         self.assertTrue(config_info["test"]["is_require"])
-        self.assertEqual(config_info["test"]["type"], "string")
+        self.assertEqual(config_info["test"]["type"], "str")
         self.assertTrue(config_info["test"]["is_require"])
 
     def test_default_option(self):
         config_info = {}
-        define_option(option_info=config_info,
-                      option_name="test",
-                      help_str="test is a help",
-                      option_type="string",
-                      default="test1")
-
-        self.assertFalse(config_info["test"]["is_require"])
-        self.assertIs(config_info["test"]["default"], "test1")
+        try:
+            define_option(option_info=config_info,
+                          option_name="test",
+                          help_str="test is a help",
+                          option_type="str",
+                          default="test1",
+                          cmd_flags="--test")
+        except:
+            self.fail("define_option should not raise exception.")
+        else:
+            self.assertIn("test", config_info)
+            self.assertFalse(config_info["test"]["is_require"])
+            self.assertIs(config_info["test"]["default"], "test1")
 
     def test_cmd_flags_option(self):
         config_info = {}
         define_option(option_info=config_info,
                       option_name="test",
                       help_str="test is a help",
-                      option_type="string",
+                      option_type="str",
                       cmd_flags="--test")
 
         self.assertIsInstance(config_info["test"]["cmd_flags"], list)
@@ -75,7 +81,7 @@ class TestDefineOption(unittest.TestCase):
         define_option(option_info=config_info,
                       option_name="test",
                       help_str="test is a help",
-                      option_type="string",
+                      option_type="str",
                       cmd_flags=["--test", "-t"])
 
         self.assertIsInstance(config_info["test"]["cmd_flags"], list)
@@ -87,8 +93,9 @@ class TestDefineOption(unittest.TestCase):
         define_option(option_info=config_info,
                       option_name="test",
                       help_str="test is a help",
-                      option_type="string",
-                      choices=["socks", "proxy"])
+                      option_type="str",
+                      choices=["socks", "proxy"],
+                      cmd_flags="--test")
 
         self.assertIsInstance(config_info["test"]["choices"], list)
         self.assertIn("socks", config_info["test"]["choices"])
@@ -99,21 +106,21 @@ class TestDefineOption(unittest.TestCase):
         define_option(option_info=config_info,
                       option_name="test",
                       help_str="test is a help",
-                      option_type="list",
-                      list_type="string")
+                      option_type="list:str",
+                      cmd_flags="--test")
 
         self.assertIn("test", config_info)
         self.assertEqual(config_info["test"]["help"], "test is a help")
         self.assertTrue(config_info["test"]["is_require"])
-        self.assertEqual(config_info["test"]["type"], "list")
-        self.assertEqual(config_info["test"]["list_type"], "string")
+        self.assertEqual(config_info["test"]["type"], "list:str")
 
     def test_incorrect_option_info(self):
         with self.assertRaises(ValueError):
             define_option(option_info=None,
                           option_name="test",
                           help_str="test is a help",
-                          option_type="string")
+                          option_type="str",
+                          cmd_flags="--test")
 
     def test_incorrect_option_type(self):
         config_info = {}
@@ -121,7 +128,8 @@ class TestDefineOption(unittest.TestCase):
             define_option(option_info=config_info,
                           option_name="test",
                           help_str="test is a help",
-                          option_type="not_a_type")
+                          option_type="not_a_type",
+                          cmd_flags="--test")
 
     def test_incorrect_list_type(self):
         config_info = {}
@@ -129,8 +137,8 @@ class TestDefineOption(unittest.TestCase):
             define_option(option_info=config_info,
                           option_name="test",
                           help_str="test is a help",
-                          option_type="list",
-                          list_type="not_a_type")
+                          option_type="list:abc",
+                          cmd_flags="--test")
 
     def test_missing_list_type(self):
         config_info = {}
@@ -138,7 +146,8 @@ class TestDefineOption(unittest.TestCase):
             define_option(option_info=config_info,
                           option_name="test",
                           help_str="test is a help",
-                          option_type="list")
+                          option_type="list",
+                          cmd_flags="--test")
 
     def test_incorrect_choices_type(self):
         config_info = {}
@@ -146,79 +155,52 @@ class TestDefineOption(unittest.TestCase):
             define_option(option_info=config_info,
                           option_name="test",
                           help_str="test is a help",
-                          option_type="string",
-                          choices="hello")
+                          option_type="str",
+                          choices="hello",
+                          cmd_flags="--test")
 
 
 class TestConfig(unittest.TestCase):
     def setUp(self):
-        proxy_option_info = {}
-        define_option(option_info=proxy_option_info,
+        self.config_field_info = {}
+        define_option(option_info=self.config_field_info,
                       option_name="host",
                       help_str="Specify the proxy host",
                       default="127.0.0.1",
-                      option_type="string",
-                      cmd_flags="--host")
+                      option_type="str",
+                      cmd_flags="--host",
+                      config_file_flags="proxy:host")
 
-        define_option(option_info=proxy_option_info,
+        define_option(option_info=self.config_field_info,
                       option_name="port",
                       help_str="Specify the proxy listening port",
                       option_type="int",
-                      cmd_flags="--port")
+                      cmd_flags="--port",
+                      config_file_flags="proxy:port")
 
-        define_option(option_info=proxy_option_info,
+        define_option(option_info=self.config_field_info,
                       option_name="http_port",
                       help_str="Add additional http port",
                       default="",
-                      option_type="list",
+                      option_type="list:int",
                       cmd_flags="--http-port",
-                      list_type="int")
-
-        viewer_option_info = {}
-        define_option(option_info=viewer_option_info,
-                      option_name="mode",
-                      help_str="Specify the viewer type",
-                      option_type="string",
-                      cmd_flags="--mode",
-                      choices=["log"])
-
-        self.config_field_info = {}
-        define_section(config_field_info=self.config_field_info,
-                       section="proxy",
-                       option_info=proxy_option_info,
-                       help_str="Open microproxy service")
-        define_section(config_field_info=self.config_field_info,
-                       section="viewer",
-                       option_info=viewer_option_info,
-                       help_str="Open viewer")
+                      config_file_flags="proxy:http.port")
 
     def test_cmd_arguments(self):
         parser = ConfigParserBuilder.setup_cmd_parser(self.config_field_info)
         arguments = [
-            "proxy",
             "--host", "127.0.0.1",
             "--port", "8080",
             "--http-port", "5000,5001"
         ]
         config = vars(parser.parse_args(arguments))
 
-        self.assertEqual(config["command_type"], "proxy")
         self.assertEqual(config["host"], "127.0.0.1")
         self.assertEqual(config["port"], "8080")
         self.assertEqual(config["http_port"], "5000,5001")
 
-        arguments = [
-            "viewer",
-            "--mode", "log"
-        ]
-        config = vars(parser.parse_args(arguments))
-
-        self.assertEqual(config["command_type"], "viewer")
-        self.assertEqual(config["mode"], "log")
-
     def test_config_options_cmd(self):
         cmd_options = {
-            "command_type": "proxy",
             "host": "127.0.0.1",
             "port": "8080",
             "http_port": "5000,5001"
@@ -226,7 +208,6 @@ class TestConfig(unittest.TestCase):
         ini_parser = Mock()
         ini_parser.items = Mock(return_value=[])
         config = gen_config(self.config_field_info, ini_parser, cmd_options)
-        self.assertEqual(config["command_type"], "proxy")
         self.assertEqual(config["host"], "127.0.0.1")
         self.assertIsInstance(config["port"], int)
         self.assertEqual(config["port"], 8080)
@@ -234,19 +215,20 @@ class TestConfig(unittest.TestCase):
         self.assertListEqual(config["http_port"], [5000, 5001])
 
     def test_config_options_ini(self):
-        cmd_options = {
-            "command_type": "proxy"
-        }
         ini_options = [
             ("host", "127.0.0.1"),
             ("port", "8080"),
             ("http.port", "5000,5001")
         ]
 
+        def ini_parser_side_effect(section, name):
+            for key, value in ini_options:
+                if name == key:
+                    return value
+
         ini_parser = Mock()
-        ini_parser.items = Mock(return_value=ini_options)
-        config = gen_config(self.config_field_info, ini_parser, cmd_options)
-        self.assertEqual(config["command_type"], "proxy")
+        ini_parser.get = Mock(side_effect=ini_parser_side_effect)
+        config = gen_config(self.config_field_info, ini_parser, {})
         self.assertEqual(config["host"], "127.0.0.1")
         self.assertIsInstance(config["port"], int)
         self.assertEqual(config["port"], 8080)
@@ -255,7 +237,6 @@ class TestConfig(unittest.TestCase):
 
     def test_config_options_overwrite(self):
         cmd_options = {
-            "command_type": "proxy",
             "host": "127.0.0.1",
             "port": "8080"
         }
@@ -264,10 +245,15 @@ class TestConfig(unittest.TestCase):
             ("port", "8000"),
             ("http.port", "5000,5001")
         ]
+
+        def ini_parser_side_effect(section, name):
+            for key, value in ini_options:
+                if name == key:
+                    return value
+
         ini_parser = Mock()
-        ini_parser.items = Mock(return_value=ini_options)
+        ini_parser.get = Mock(side_effect=ini_parser_side_effect)
         config = gen_config(self.config_field_info, ini_parser, cmd_options)
-        self.assertEqual(config["command_type"], "proxy")
         self.assertEqual(config["host"], "127.0.0.1")
         self.assertIsInstance(config["port"], int)
         self.assertEqual(config["port"], 8080)
@@ -276,7 +262,6 @@ class TestConfig(unittest.TestCase):
 
     def test_missing_requre_field(self):
         config = {
-            "command_type": "proxy",
             "host": "127.0.0.1",
             "http_port": [5000],
         }
@@ -286,16 +271,14 @@ class TestConfig(unittest.TestCase):
 
     def test_incorect_value(self):
         config = {
-            "command_type": "viewer",
             "mode": "not_exist"
         }
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(KeyError):
             verify_config(self.config_field_info, config)
 
     def test_unknown_field(self):
         config = {
-            "command_type": "proxy",
             "host": "127.0.0.1",
             "port": 5580,
             "http_port": [5000],

--- a/setup.py
+++ b/setup.py
@@ -49,10 +49,28 @@ setup(
     include_package_data=True,
     entry_points={
         'console_scripts': [
-            "microproxy=microproxy.command_line:main",
+            "mpserver=microproxy.command_line:mpserver",
+            "mptui=microproxy.command_line:mptui",
+            "mpdump=microproxy.command_line:mpdump",
         ]
     },
-    install_requires=proxy_deps,
+    install_requires=[
+        "tornado==4.3",
+        "pyzmq==15.4.0",
+        "watchdog==0.8.3",
+        "pyOpenSSL==16.0.0",
+        "service-identity==16.0.0",
+        "certifi==2016.8.8",
+        "construct==2.5.3",
+        "six==1.10.0",
+        "h2==2.4.0",
+        "h11==0.5.0+dev",
+        "socks5==0.1.0"
+    ],
+    dependency_links=[
+        "https://github.com/chhsiao90/h11/tarball/master#egg=h11-0.5.0+dev",
+        "https://github.com/mike820324/socks5/tarball/master#egg=socks5-0.1.0"
+    ],
     extras_require={
         'viewer': viewer_deps,
         'develop': dev_deps


### PR DESCRIPTION
Hi @chhsiao90, 
finally, I have finished the refine config part, sorry for taking so long. The PR changed the following part.
- add `list:str`, `list:int` instead of using list option type.
- change `string` and `boolean` into `str` and `bool`.
- properly support boolean type.
- add new parameter, config_file_flags to define section and key of config file.
- change the layout proxy config file.

Help me review this a bit, any suggestion would be helpful.

TODO:
- unittest
- setup.py
