### PR TITLE
Upgrade h11 to 0.6.0-dev.

### DIFF
--- a/microproxy/protocol/http1.py
+++ b/microproxy/protocol/http1.py
@@ -125,7 +125,7 @@ class Connection(H11Connection):
             method=request.method,
             target=request.path,
             headers=request.headers,
-            keep_case=True))
+        ))
         if request.body:
             self.send(h11.Data(data=request.body))
         self.send(h11.EndOfMessage())
@@ -136,7 +136,7 @@ class Connection(H11Connection):
             status_code=int(response.code),
             reason=response.reason,
             headers=response.headers,
-            keep_case=True))
+        ))
         if response.body:
             self.send(h11.Data(data=response.body))
         self.send(h11.EndOfMessage())
@@ -149,7 +149,7 @@ class Connection(H11Connection):
             status_code=int(response.code),
             headers=response.headers,
             reason=response.reason,
-            keep_case=True))
+        ))
 
     def _default_on_unhandled(self, *args):  # pragma: no cover
         logger.warn("unhandled event: {0}".format(args))

--- a/microproxy/test/event/test_replay.py
+++ b/microproxy/test/event/test_replay.py
@@ -68,7 +68,7 @@ class TestReplayHandler(AsyncTestCase):
         self.assertEqual(req.version, "HTTP/1.1")
         self.assertEqual(req.path, "/")
         self.assertEqual(req.headers, HttpHeaders([
-            ("Host", "localhost")]))
+            ("host", "localhost")]))
 
     @gen_test
     def test_http1_post_body(self):
@@ -100,8 +100,8 @@ class TestReplayHandler(AsyncTestCase):
         self.assertEqual(req.version, "HTTP/1.1")
         self.assertEqual(req.path, "/")
         self.assertEqual(req.headers, HttpHeaders([
-            ("Host", "localhost"),
-            ("Content-Length", str(body_length))]))
+            ("host", "localhost"),
+            ("content-length", str(body_length))]))
         self.assertEqual(req.body, body)
 
     @gen_test

--- a/microproxy/test/layer/test_http1.py
+++ b/microproxy/test/layer/test_http1.py
@@ -76,7 +76,7 @@ class TestHttp1Layer(ProxyAsyncTestCase):
         self.assertEqual(request.method, "GET")
         self.assertEqual(request.version, "HTTP/1.1")
         self.assertEqual(request.path, "/index")
-        self.assertEqual(request.headers, HttpHeaders([("Host", "localhost")]))
+        self.assertEqual(request.headers, HttpHeaders([("host", "localhost")]))
 
         self.server_conn.send_response(HttpResponse(
             version="HTTP/1.1", code="200", reason="OK",
@@ -141,7 +141,7 @@ class TestHttp1Layer(ProxyAsyncTestCase):
         self.assertEqual(request.method, "GET")
         self.assertEqual(request.version, "HTTP/1.1")
         self.assertEqual(request.path, "/index")
-        self.assertEqual(request.headers, HttpHeaders([("Host", "localhost")]))
+        self.assertEqual(request.headers, HttpHeaders([("host", "localhost")]))
 
         self.client_stream.close()
 
@@ -168,7 +168,7 @@ class TestHttp1Layer(ProxyAsyncTestCase):
         self.assertEqual(request.method, "GET")
         self.assertEqual(request.version, "HTTP/1.1")
         self.assertEqual(request.path, "/index")
-        self.assertEqual(request.headers, HttpHeaders([("Host", "localhost")]))
+        self.assertEqual(request.headers, HttpHeaders([("host", "localhost")]))
 
         self.server_conn.send_response(HttpResponse(
             version="HTTP/1.1", code="200", reason="OK",
@@ -208,8 +208,8 @@ class TestHttp1Layer(ProxyAsyncTestCase):
         self.assertEqual(request.version, "HTTP/1.1")
         self.assertEqual(request.path, "/chat")
         self.assertEqual(request.headers,
-                         HttpHeaders([("Host", "localhost"),
-                                      ("Upgrade", "websocket")]))
+                         HttpHeaders([("host", "localhost"),
+                                      ("upgrade", "websocket")]))
 
         self.server_conn.send_info_response(HttpResponse(
             version="HTTP/1.1", code="101", reason="Switching Protocol",
@@ -224,7 +224,7 @@ class TestHttp1Layer(ProxyAsyncTestCase):
         self.assertEqual(response.reason, "Switching Protocol")
         self.assertEqual(
             response.headers,
-            HttpHeaders([("Upgrade", "websocket"), ("Connection", "Upgrade")]))
+            HttpHeaders([("upgrade", "websocket"), ("connection", "Upgrade")]))
 
         self.assertTrue(http_layer_future.done())
         yield http_layer_future
@@ -245,7 +245,7 @@ class TestHttp1Layer(ProxyAsyncTestCase):
         self.assertEqual(request.method, "GET")
         self.assertEqual(request.version, "HTTP/1.1")
         self.assertEqual(request.path, "/index")
-        self.assertEqual(request.headers, HttpHeaders([("Host", "localhost")]))
+        self.assertEqual(request.headers, HttpHeaders([("host", "localhost")]))
 
         yield self.server_stream.write(
             (b"HTTP/1.1 200 OK\r\n"
@@ -285,7 +285,7 @@ class TestHttp1Layer(ProxyAsyncTestCase):
         self.assertEqual(request.method, "GET")
         self.assertEqual(request.version, "HTTP/1.1")
         self.assertEqual(request.path, "/chat")
-        self.assertEqual(request.headers, HttpHeaders([("Host", "localhost"), ("Upgrade", "websocket")]))
+        self.assertEqual(request.headers, HttpHeaders([("host", "localhost"), ("upgrade", "websocket")]))
 
         self.client_stream.close()
 

--- a/microproxy/test/protocol/test_http1.py
+++ b/microproxy/test/protocol/test_http1.py
@@ -38,7 +38,7 @@ class TestConnection(ProxyAsyncTestCase):
 
         self.assertIsNotNone(self.request)
         self.assertEqual(self.request.headers,
-                         HttpHeaders([("Host", "localhost")]))
+                         HttpHeaders([("host", "localhost")]))
         self.assertEqual(self.request.method, "GET")
         self.assertEqual(self.request.path, "/")
         self.assertEqual(self.request.version, "HTTP/1.1")
@@ -58,8 +58,8 @@ class TestConnection(ProxyAsyncTestCase):
 
         self.assertIsNotNone(self.response)
         self.assertEqual(self.response.headers,
-                         HttpHeaders([("Host", "localhost"),
-                                      ("Content-Length", "1")]))
+                         HttpHeaders([("host", "localhost"),
+                                      ("content-length", "1")]))
         self.assertEqual(self.response.code, "200")
         self.assertEqual(self.response.reason, "OK")
         self.assertEqual(self.response.version, "HTTP/1.1")
@@ -84,8 +84,8 @@ class TestConnection(ProxyAsyncTestCase):
 
         self.assertIsNotNone(self.response)
         self.assertEqual(self.response.headers,
-                         HttpHeaders([("Host", "localhost"),
-                                      ("Upgrade", "websocket")]))
+                         HttpHeaders([("host", "localhost"),
+                                      ("upgrade", "websocket")]))
         self.assertEqual(self.response.code, "101")
         self.assertEqual(self.response.reason, "Protocol Upgrade")
         self.assertEqual(self.response.version, "HTTP/1.1")
@@ -104,7 +104,7 @@ class TestConnection(ProxyAsyncTestCase):
 
         self.assertIsNotNone(self.request)
         self.assertEqual(self.request.headers,
-                         HttpHeaders([("Host", "localhost"), ("Content-Length", "4")]))
+                         HttpHeaders([("host", "localhost"), ("content-length", "4")]))
         self.assertEqual(self.request.method, "POST")
         self.assertEqual(self.request.path, "/")
         self.assertEqual(self.request.version, "HTTP/1.1")

--- a/setup.py
+++ b/setup.py
@@ -64,11 +64,11 @@ setup(
         "construct==2.5.3",
         "six==1.10.0",
         "h2==2.4.0",
-        "h11==0.5.0+dev",
+        "h11==0.6.0+dev",
         "socks5==0.1.0"
     ],
     dependency_links=[
-        "https://github.com/chhsiao90/h11/tarball/master#egg=h11-0.5.0+dev",
+        "https://github.com/njsmith/h11/tarball/master#egg=h11-0.6.0+dev",
         "https://github.com/mike820324/socks5/tarball/master#egg=socks5-0.1.0"
     ],
     extras_require={


### PR DESCRIPTION
Upgrade h11 to 0.6.0-dev.
- remove the `keep_case` parameter.
- upgrade unittest

P.S
Since the `response.reason` support of h11 is still in master branch,
we still need to install it from github.
