### PR TITLE
Resolved #218: add default value for mpdump.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,9 @@ coverage:
 	@coverage run --source=microproxy -m unittest discover
 
 install:
-	pip install -U --no-deps .
+	pip install -U --no-deps --process-dependency-links .
 
 install-all:
-	pip install -U .
+	pip install -U --process-dependency-links .
 	pip install -U .[viewer]
-	pip install -U .[dev]
+	pip install -U .[develop]

--- a/microproxy/command_line.py
+++ b/microproxy/command_line.py
@@ -134,6 +134,7 @@ def create_console_viewer_options():
                   help_str="Specify the proxy host. ex. tcp://127.0.0.1",
                   option_type="str",
                   cmd_flags="--proxy-host",
+                  default="tcp://127.0.0.1",
                   config_file_flags="channel:host")
 
     define_option(option_info=console_viewer_option_info,
@@ -141,6 +142,7 @@ def create_console_viewer_options():
                   help_str="Specify the viewer channel port. ex. 5581",
                   option_type="int",
                   cmd_flags="--viewer-channel-port",
+                  default="5581",
                   config_file_flags="channel:viewer.port")
 
     define_option(option_info=console_viewer_option_info,
@@ -148,6 +150,7 @@ def create_console_viewer_options():
                   help_str="Specify the events channel port. ex. 5582",
                   option_type="int",
                   cmd_flags="--events-channel-port",
+                  default="5582",
                   config_file_flags="channel:events.port")
 
     define_option(option_info=console_viewer_option_info,


### PR DESCRIPTION
Add default value for the following options.

- proxy-host
- event-channel
- viewer-channel