### PR TITLE
Use commit hash to tag h11 version.

### DIFF
--- a/requirements/proxy.txt
+++ b/requirements/proxy.txt
@@ -8,5 +8,5 @@ construct==2.5.3
 six==1.10.0
 h2==2.4.0
 
--e git+https://github.com/njsmith/h11.git#egg=h11
+-e git+https://github.com/njsmith/h11.git@9c0a553d20af50e832f4317e7943986a0a4423f7#egg=h11
 -e git+https://github.com/mike820324/socks5.git@v0.1.0#egg=socks5

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
         "socks5==0.1.0"
     ],
     dependency_links=[
-        "https://github.com/njsmith/h11/tarball/master#egg=h11-0.6.0+dev",
+        "https://github.com/njsmith/h11/tarball/9c0a553d20af50e832f4317e7943986a0a4423f7#egg=h11-0.6.0+dev",
         "https://github.com/mike820324/socks5/archive/v0.1.0.tar.gz#egg=socks5-0.1.0"
     ],
     extras_require={


### PR DESCRIPTION

To avoid the potential api change when h11 master change merged new commits.