### PR TITLE
Mark closed over detached IOStream

### DIFF
--- a/microproxy/tornado_ext/iostream.py
+++ b/microproxy/tornado_ext/iostream.py
@@ -109,6 +109,7 @@ class MicroProxyIOStream(IOStream):
         _socket = self.socket
         self.io_loop.remove_handler(_socket)
         self.socket = None
+        self._closed = True
         return _socket
 
     def start_tls(self, server_side, ssl_options, server_hostname=None):


### PR DESCRIPTION
Resolved #234 

Mark IOStream as closed while it had been detached,
so that it wont raise Exception when try close it